### PR TITLE
Fixes some corner cases like misc/logs for Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
 
+## 0.1.2
+- Fixes corner cases like `misc/logs` for Pods
+
 ## 0.1.0
 - Initial version

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ kubernetes-api is a Clojure library that acts as a kubernetes client
 
 ## Motivation
 
-We had a good experience with 
- [cognitect-labs/aws-api](https://github.com/cognitect-labs/aws-api), and missed 
- something like that for Kubernetes API. We had some client libraries that 
+We had a good experience with
+ [cognitect-labs/aws-api](https://github.com/cognitect-labs/aws-api), and missed
+ something like that for Kubernetes API. We had some client libraries that
  generated a lot of code, but it lacked discoverability and documentation.
 
 ### clojure.deps
 ```clojure
-{:deps {nubank/k8s-api {:mvn/version "0.1.0-SNAPSHOT"}}}
+{:deps {nubank/k8s-api {:mvn/version "0.1.2"}}}
 ```
 
 ### Leiningen
 ```clojure
-[nubank/k8s-api "0.1.0-SNAPSHOT"]
+[nubank/k8s-api "0.1.2"]
 ```
 
 ```clojure
@@ -29,7 +29,7 @@ We had a good experience with
 ## Usage
 ### Instantiate a client
 
-There're multiple options for authentication while instantiating a client. You 
+There're multiple options for authentication while instantiating a client. You
 can explicit set a token:
 ```clojure
 (def k8s (k8s/client "http://some.host" {:token "..."}))
@@ -57,7 +57,7 @@ You can list all operations with
 or specify a specific entity
 ```clojure
 (k8s/explore k8s :Deployment)
-;=> 
+;=>
 [:Deployment
  [:get "read the specified Deployment"]
  [:update "replace the specified Deployment"]
@@ -101,7 +101,7 @@ get info on an operation
 
 ### Invoke
 
-You can call an operation with 
+You can call an operation with
 ```clojure
 (k8s/invoke k8s {:kind    :ConfigMap
                  :action  :create
@@ -127,4 +127,3 @@ You can debug the request map with
                             :body      {:apiVersion "v1"
                                         :data       {"foo" "bar"}}}})
 ```
-

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.1.1"
+(defproject nubank/k8s-api "0.1.2"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/internals/client.clj
+++ b/src/kubernetes_api/internals/client.clj
@@ -63,11 +63,13 @@
     (all-namespaces-route? route-name) (keyword (str (name (handler-action handler)) "-all"))
     :else (handler-action handler)))
 
-(defn find-route [k8s {:keys [kind action all-namespaces?] :as _search-params}]
+(defn find-route [k8s {:keys [all-namespaces?] :as _search-params
+                       search-kind :kind
+                       search-action :action}]
   (->> (:handlers k8s)
        (filter (fn [handler]
-                 (and (or (= (keyword kind) (handler-kind handler)) (nil? kind))
-                      (or (= (keyword action) (handler-action handler)) (nil? action))
+                 (and (or (= (keyword search-kind) (kind handler)) (nil? search-kind))
+                      (or (= (keyword search-action) (action handler)) (nil? search-action))
                       (= (boolean all-namespaces?) (all-namespaces-route? (:route-name handler))))))
        (map :route-name)))
 


### PR DESCRIPTION
There are some kinds in Kubernetes that have more than one action `get` in the swagger specification, like Pods.
It has the same action `get` mapped to `pod/logs` and `pods`, so we remapped those on the `action` internal function.

The problem is that this function was not being used to find the martian route to trigger, but the `handler-action`, a much simpler function that doesn't deal with those corner cases.

We could have the same issue with `kind` and `handler-kind`, since we remap kinds like `DeploymentStatus`, since in swagger it's also mapped to the kind `Deployment`, which can be very confusing.

The effect of this bug it's that when you called `get` operation on Pod, you would call logs endpoint instead.