### PR TITLE
Fixes PATCH operations to accept a raw string as the body parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.1.3
+- Fixes PATCH operations to work properly
+
 ## 0.1.2
 - Fixes corner cases like `misc/logs` for Pods
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ We had a good experience with
 
 ### clojure.deps
 ```clojure
-{:deps {nubank/k8s-api {:mvn/version "0.1.2"}}}
+{:deps {nubank/k8s-api {:mvn/version "0.1.3"}}}
 ```
 
 ### Leiningen
 ```clojure
-[nubank/k8s-api "0.1.2"]
+[nubank/k8s-api "0.1.3"]
 ```
 
 ```clojure
@@ -101,12 +101,13 @@ get info on an operation
 
 ### Invoke
 
-You can call an operation with
+You can call an operation with:
 ```clojure
 (k8s/invoke k8s {:kind    :ConfigMap
                  :action  :create
                  :request {:namespace "default"
                            :body      {:apiVersion "v1"
+                                       :metadata   {:name "my-awesome-cm"}
                                        :data       {"foo" "bar"}}}})
 ```
 
@@ -119,11 +120,28 @@ invoke it will return the body, with `:request` and `:response` in metadata
             :body ...}}
 ```
 
-You can debug the request map with
+You can debug the request map with:
 ```clojure
 (k8s/request k8s {:kind    :ConfigMap
                   :action  :create
                   :request {:namespace "default"
                             :body      {:apiVersion "v1"
+                                        :metadata   {:name "my-awesome-cm"}
                                         :data       {"foo" "bar"}}}})
+```
+
+#### Invoking PATCH operations
+
+The `:body` parameter in PATCH is a bit different from the other operations, it must be a `String`.
+It's due to the need for the request body to comply to the chosen patch strategy (that can be a
+Strategic Merge Patch, a JSON Patch or a JSON Merge Patch. More details
+[here](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/)).
+
+You can call a PATCH operation with:
+```clojure
+(k8s/invoke k8s {:kind    :ConfigMap
+                 :action  :patch
+                 :request {:namespace "default"
+                           :name      "my-awesome-cm"
+                           :body      "{\"data\": {\"foo\": \"another-value\"}}"}})
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.1.2"
+(defproject nubank/k8s-api "0.1.3"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -123,4 +123,3 @@
     schemas"
   [k8s params]
   (martian/explore k8s (internals.client/find-preferred-route k8s (dissoc params :request))))
-

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -77,22 +77,19 @@
 (defn fix-patch-object-definition
   "Patch operations have an 'io.k8s.apimachinery.pkg.apis.meta.v1.Patch' as the 'body' parameter
   schema definition, but this definition is of the type `object` without any property, so it generates
-  a ':body {}' in the client schema that doesn't allow to pass anything in the body for
-  a PATCH operation.
+  a ':body {}' in the client schema that doesn't allow to pass anything in the body for a PATCH operation.
 
-  Changing the type to 'string' is the approach used by clients in other languages and will
-  allow to pass the request body data as a raw value. Official Kubernetes Java Client also treats
-  this way.
+  Removing the type from this definition generates a ':body Any' in the client schema that
+  allow to pass the request body data as a raw string value.
 
   More details about this behavior can be found here:
   https://github.com/kubernetes/kubernetes/issues/54332
   https://github.com/kubernetes-client/gen
-  https://github.com/kubernetes-client/gen/pull/140
   "
   [swagger]
   (let [v1-patch :io.k8s.apimachinery.pkg.apis.meta.v1.Patch]
     (if (contains? (:definitions swagger) v1-patch)
-      (assoc-in swagger [:definitions v1-patch :type] "string")
+      (update-in swagger [:definitions v1-patch] dissoc :type)
       swagger)))
 
 (defn add-some-routes

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -75,11 +75,20 @@
                   :schema {:type "string"}}]}})
 
 (defn fix-patch-object-definition
-  "Patch operations have the body property as the schema as an io.k8s.apimachinery.pkg.apis.meta.v1.Patch,
-  but this definition is a type object without any property, so it generates a `:body {}` that doesn't
-  allow us to pass anything to the PATCH operation.
+  "Patch operations have an 'io.k8s.apimachinery.pkg.apis.meta.v1.Patch' as the 'body' parameter
+  schema definition, but this definition is of the type `object` without any property, so it generates
+  a ':body {}' in the client schema that doesn't allow to pass anything in the body for
+  a PATCH operation.
 
-  Changing the type to `string` allow us to pass the patch data as a raw value"
+  Changing the type to 'string' is the approach used by clients in other languages and will
+  allow to pass the request body data as a raw value. Official Kubernetes Java Client also treats
+  this way.
+
+  More details about this behavior can be found here:
+  https://github.com/kubernetes/kubernetes/issues/54332
+  https://github.com/kubernetes-client/gen
+  https://github.com/kubernetes-client/gen/pull/140
+  "
   [swagger]
   (let [v1-patch :io.k8s.apimachinery.pkg.apis.meta.v1.Patch]
     (if (contains? (:definitions swagger) v1-patch)

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -74,6 +74,15 @@
                   :name   "version"
                   :schema {:type "string"}}]}})
 
+(defn fix-patch-object-definition
+  "Patch operations have the body property as the schema as an io.k8s.apimachinery.pkg.apis.meta.v1.Patch,
+  but this definition is a type object without any property, so it generates a `:body {}` that doesn't
+  allow us to pass anything to the PATCH operation.
+
+  Changing the type to `string` allow us to pass the patch data as a raw value"
+  [swagger]
+  (assoc-in swagger [:definitions :io.k8s.apimachinery.pkg.apis.meta.v1.Patch :type] "string"))
+
 (defn add-some-routes
   [swagger new-definitions new-routes]
   (-> swagger
@@ -87,6 +96,7 @@
   (-> swagger
       add-summary
       (add-some-routes {} arbitrary-api-resources-route)
+      fix-patch-object-definition
       fix-k8s-verb
       fix-consumes
       remove-watch-endpoints))

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -81,7 +81,10 @@
 
   Changing the type to `string` allow us to pass the patch data as a raw value"
   [swagger]
-  (assoc-in swagger [:definitions :io.k8s.apimachinery.pkg.apis.meta.v1.Patch :type] "string"))
+  (let [v1-patch :io.k8s.apimachinery.pkg.apis.meta.v1.Patch]
+    (if (contains? (:definitions swagger) v1-patch)
+      (assoc-in swagger [:definitions v1-patch :type] "string")
+      swagger)))
 
 (defn add-some-routes
   [swagger new-definitions new-routes]

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -43,8 +43,7 @@
 (deftest fix-patch-object-definition-test
   (testing "fixes patch object definition when it exists"
     (is (= {:definitions {:io.k8s.apimachinery.pkg.apis.meta.v1.Patch
-                          {:description "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
-                           :type        "string"}}}
+                          {:description "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."}}}
            (swagger/fix-patch-object-definition
              {:definitions {:io.k8s.apimachinery.pkg.apis.meta.v1.Patch
                             {:description "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -40,6 +40,24 @@
            (swagger/fix-consumes
             {:paths {"/foo/bar" {:get {:consumes ["application/yaml"]}}}})))))
 
+(deftest fix-patch-object-definition-test
+  (testing "fixes patch object definition when it exists"
+    (is (= {:definitions {:io.k8s.apimachinery.pkg.apis.meta.v1.Patch
+                          {:description "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+                           :type        "string"}}}
+           (swagger/fix-patch-object-definition
+             {:definitions {:io.k8s.apimachinery.pkg.apis.meta.v1.Patch
+                            {:description "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+                             :type        "object"}}}))))
+  (testing "leave unaltered when it doesn't exist"
+    (is (= {:definitions {:io.k8s.apimachinery.pkg.api.resource.Quantity
+                          {:description "Quantity is a fixed-point representation of a number."
+                           :type        "string"}}}
+           (swagger/fix-patch-object-definition
+             {:definitions {:io.k8s.apimachinery.pkg.api.resource.Quantity
+                            {:description "Quantity is a fixed-point representation of a number."
+                             :type        "string"}}})))))
+
 (deftest add-summary-test
   (testing "copies description to summary if summary doesnt exists"
     (is (= {:paths {"/foo/bar" {:get {:description "foo"


### PR DESCRIPTION
Patch operations have an `io.k8s.apimachinery.pkg.apis.meta.v1.Patch` as the `body` parameter schema definition, but this definition is of the type `object` without any property:

```json
    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
      "type": "object"
    }
```
so it generates a `:body {}` in the client schema that doesn't allow to pass anything in the body for a PATCH operation:
```
{:summary "partially update the specified ConfigMap",
 :parameters
 {:name java.lang.String,
  :namespace java.lang.String,
  {:k :pretty} (maybe Str),
  {:k :dry-run} (maybe Str),
  {:k :field-manager} (maybe Str),
  {:k :force} (maybe Bool),
  :body {}},
```

Removing the type from this definition generates a `:body Any` in the client schema that will allow us to pass the request body data as a raw string value.

And it's also a similar approach used to generate the clients in the official Kubernetes code gen repo: 
https://github.com/kubernetes-client/gen

More details about this behavior can be found here:
https://github.com/kubernetes/kubernetes/issues/54332
