### PR TITLE
Add support for patch strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.0-SNAPSHOT
+- Add support for JSON Patch, JSON Merge, Strategic Merge Patch and Server-Side
+Apply requests.
+
 ## 0.1.2
 - Fixes corner cases like `misc/logs` for Pods
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can call an operation with
 (k8s/invoke k8s {:kind    :ConfigMap
                  :action  :create
                  :request {:namespace "default"
-                           :body      {:apiVersion "v1"
+                           :body      {:api-version "v1"
                                        :data       {"foo" "bar"}}}})
 ```
 
@@ -124,6 +124,9 @@ You can debug the request map with
 (k8s/request k8s {:kind    :ConfigMap
                   :action  :create
                   :request {:namespace "default"
-                            :body      {:apiVersion "v1"
+                            :body      {:api-version "v1"
                                         :data       {"foo" "bar"}}}})
 ```
+
+If you want to read more about all different patch strategies Kubernetes offers,
+[check this document](doc/kubernetes-patch-strategies.md)

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,0 @@
-# Introduction to kubernetes-api
-
-TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/doc/kubernetes-patch-strategies.md
+++ b/doc/kubernetes-patch-strategies.md
@@ -38,7 +38,7 @@ conceptual differences. You have the full description [here][rfc7386].
 
 The body of the request is similar to a diff, meaning that you only need to
 describe what is going to change. This strategy tries to move away from the JSON
-Patch imperiative approach by allowing you to describe a data structure similar
+Patch imperative approach by allowing you to describe a data structure similar
 to the one you're patching.
 
 In the Kubernetes API, this is done by setting Content-Type header to

--- a/doc/kubernetes-patch-strategies.md
+++ b/doc/kubernetes-patch-strategies.md
@@ -87,7 +87,7 @@ Note that this strategy is not available for Custom Resource Definitions yet.
 ```
 
 Note that this strategy allow you to customize containers inside a Deployment,
-without having to worry about the order they are defined or the existance of
+without having to worry about the order they are defined or the existence of
 other containers.
 
 In the Kubernetes API, this is done by setting Content-Type header to

--- a/doc/kubernetes-patch-strategies.md
+++ b/doc/kubernetes-patch-strategies.md
@@ -1,7 +1,7 @@
 # Kubernetes Patch Strategies
 
 The official Kubernetes documentation has great information about patches and
-their uses [here][k8s-doc]. This document it's an overview to what to expect and
+their uses [here][k8s-doc]. This document is an overview to what to expect and
 how to use them.
 
 ## JSON Patch RFC-6902

--- a/doc/kubernetes-patch-strategies.md
+++ b/doc/kubernetes-patch-strategies.md
@@ -1,0 +1,114 @@
+# Kubernetes Patch Strategies
+
+The official Kubernetes documentation has great information about patches and
+their uses [here][k8s-doc]. This document it's an overview to what to expect and
+how to use them.
+
+## JSON Patch RFC-6902
+This is the simpler patch Kubernetes supports. You have the full description
+[here][rfc6902]. The `op` field can be `add`, `remove`, `replace`, `move`,
+`copy` and `test`.
+
+The `path` is a slash-separated field list to get to the value you desire to
+patch, described by the [JSON Pointer RFC-6901][rfc6901]. You can use `~0` and
+`~1` to describe fields with `~` and `/` characters, respectively.
+
+The `value` field is usually the value you want to add in our manifest.
+
+In the Kubernetes API, this is done by setting Content-Type header to
+`application/json-patch+json`, and in this library is defined by the action
+`:patch/json`.
+
+This style of patching is quite good when you only want to change a simple field,
+like changing `replicas` in a Deployment or adding a specific label.
+
+```clojure
+(k8s/invoke c {:kind :Deployment
+               :action :patch/json
+               :request {:name "nginx-deployment"
+                         :namespace "default"
+                         :body [{:op "add"
+                                 :path "/spec/replicas"
+                                 :value 2}]}})
+
+```
+## JSON Merge Patch RFC-7286
+This patch can be used for the same purpose of the JSON Patch, but has some
+conceptual differences. You have the full description [here][rfc7386].
+
+The body of the request is similar to a diff, meaning that you only need to
+describe what is going to change. This strategy tries to move away from the JSON
+Patch imperiative approach by allowing you to describe a data structure similar
+to the one you're patching.
+
+In the Kubernetes API, this is done by setting Content-Type header to
+`application/merge-patch+json`, and in this library is defined by the action
+`:patch/json-merge`.
+
+
+```clojure
+(k8s/invoke c {:kind :Deployment
+               :action :patch/json-merge
+               :request {:name "nginx-deployment"
+                         :namespace "default"
+                         :body {:kind "Deployment"
+                                :api-version "apps/v1"
+                                :spec {:template {:spec {:containers [{:name "sidecar"
+                                                                       :image "sidecar:v2"
+                                                                       :ports [{:container-port 8080}]}
+                                                                      {:name "nginx"
+                                                                       :image "nginx:1.14.2"
+                                                                       :ports [{:container-port 80}]}]}}}}}})
+```
+
+Note that you don't have to explicit set all fields from the Deployment, only
+those that are relevant for your patch. Also note that for lists, it will
+substitute the whole list, so you need to be careful.
+
+## Strategic Merge Patch
+
+Since neither of the other patch strategies have a good way to deal with lists,
+Kubernetes decided to introduce a new "strategic" merge patch. It is "strategic"
+meaning that it knows enough about the manifest's structure to make decisions
+about how to merge them. Read more [here][notes-on-the-strategic-merge-patch].
+
+Note that this strategy is not available for Custom Resource Definitions yet.
+
+```clojure
+(k8s/invoke c {:kind :Deployment
+               :action :patch/strategic
+               :request {:name "nginx-deployment"
+                         :namespace "default"
+                         :body {:kind "Deployment"
+                                :spec {:template {:spec {:containers [{:name "nginx"
+                                                                       :image "nginx:1.14.1"
+                                                                       :ports [{:name "metrics"
+                                                                                :container-port 80}]}]}}}}}})
+```
+
+Note that this strategy allow you to customize containers inside a Deployment,
+without having to worry about the order they are defined or the existance of
+other containers.
+
+In the Kubernetes API, this is done by setting Content-Type header to
+`application/strategic-merge-patch+json`, and in this library is defined by the
+action `:patch/strategic`.
+
+## Server-Side Apply
+
+This strategy is similar in the way you describe the change, but adds a layer of
+ownership of fields, automatically adding values to `metadata.managedFields`
+field. This allows you to identify conflicting changes from multiple sources.
+Read more [here][server-side-apply]
+
+In the Kubernetes API, this is done by setting Content-Type header to
+`application/apply-patch+yaml`, and in this library is defined by the
+action `:apply/server`.
+
+[k8s-doc]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/
+[rfc6902]: https://www.rfc-editor.org/rfc/rfc6902
+[rfc6901]: https://www.rfc-editor.org/rfc/rfc6901
+[rfc7386]: https://www.rfc-editor.org/rfc/rfc7386
+[notes-on-the-strategic-merge-patch]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch
+
+[server-side-apply]: https://kubernetes.io/docs/reference/using-api/server-side-apply/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.1.2"
+(defproject nubank/k8s-api "0.2.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -9,18 +9,9 @@
             [kubernetes-api.swagger :as swagger]
             [martian.core :as martian]
             [martian.interceptors :as interceptors]
-            [martian.encoders :as encoders]
             [martian.httpkit :as martian-httpkit]
             martian.swagger))
 
-(defn patch-encoders []
-  (let [json (get (encoders/default-encoders) "application/json")]
-    (merge
-     (encoders/default-encoders)
-     {"application/merge-patch+json" json
-      "application/strategic-merge-patch+json" json
-      "application/apply-patch+yaml" json
-      "application/json-patch+json" json})))
 
 (defn client
   "Creates a Kubernetes Client compliant with martian api and its helpers

--- a/src/kubernetes_api/interceptors/encoders.clj
+++ b/src/kubernetes_api/interceptors/encoders.clj
@@ -1,0 +1,17 @@
+(ns kubernetes-api.interceptors.encoders
+  (:require martian.encoders
+            martian.interceptors))
+
+(defn patch-encoders [json]
+  {"application/merge-patch+json" json
+   "application/strategic-merge-patch+json" json
+   "application/apply-patch+yaml" json
+   "application/json-patch+json" json})
+
+(defn default-encoders []
+  (let [encoders (martian.encoders/default-encoders)]
+    (merge encoders (patch-encoders (get encoders "application/json")))))
+
+
+(defn new []
+  (martian.interceptors/encode-body (default-encoders)))

--- a/test/kubernetes_api/internals/client_test.clj
+++ b/test/kubernetes_api/internals/client_test.clj
@@ -1,6 +1,7 @@
 (ns kubernetes-api.internals.client-test
   (:require [clojure.test :refer :all]
             [kubernetes-api.internals.client :as internals.client]
+            [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as m]))
 
 (deftest pascal-case-routes-test
@@ -8,6 +9,28 @@
                      {:route-name :DuDuduEdu}]}
          (internals.client/pascal-case-routes {:handlers [{:route-name :foo-bar}
                                                           {:route-name :du-dudu-edu}]}))))
+
+(deftest patch-http-verb-test
+  (is (= {:handlers [{:route-name :Route66
+                      :method :patch}
+                     {:route-name :Route67
+                      :method :patch}
+                     {:route-name :Route68
+                      :method :patch}
+                     {:route-name :Route69
+                      :method :patch}
+                     {:route-name :Route70
+                      :method :get}]}
+         (internals.client/patch-http-verb {:handlers [{:route-name :Route66
+                                                        :method :patch/json}
+                                                       {:route-name :Route67
+                                                        :method :patch/json-merge}
+                                                       {:route-name :Route68
+                                                        :method :patch/strategic}
+                                                       {:route-name :Route69
+                                                        :method :apply/server}
+                                                       {:route-name :Route70
+                                                        :method :get}]}))))
 
 (deftest swagger-definition-for-route-test
   (is (= 'swagger-definition
@@ -40,11 +63,29 @@
   (is (= :Deployment
          (internals.client/kind {:route-name         :CreateV1NamespacedDeployment
                                  :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}})))
+
   (is (= :Deployment/Scale
          (internals.client/kind {:route-name         :CreateAutoscalingNamespacedDeploymentScale
                                  :swagger-definition {:x-kubernetes-group-version-kind {:kind "Scale"}}})))
+
   (is (= :Deployment/Status
          (internals.client/kind {:route-name         :CreateV1NamespacedDeploymentStatus
+                                 :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}})))
+
+  (is (= :Deployment/Status
+         (internals.client/kind {:route-name         :CreateV1NamespacedDeploymentStatusJsonPatch
+                                 :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}})))
+
+  (is (= :Deployment/Status
+         (internals.client/kind {:route-name         :CreateV1NamespacedDeploymentStatusStrategicMerge
+                                 :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}})))
+
+  (is (= :Deployment/Status
+         (internals.client/kind {:route-name         :CreateV1NamespacedDeploymentStatusJsonMerge
+                                 :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}})))
+
+  (is (= :Deployment/Status
+         (internals.client/kind {:route-name         :CreateV1NamespacedDeploymentStatusApplyServerSide
                                  :swagger-definition {:x-kubernetes-group-version-kind {:kind "Deployment"}}}))))
 
 (deftest action-test

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -51,24 +51,28 @@
                                                   :x-kubernetes-action "patch/json"}
                                      :patch/json-merge {:parameters [{:name "body"
                                                                       :in "body"
-                                                                      :schema {}}]
+                                                                      :schema 'schema}]
                                                         :operationId "PatchCoreV1ResourceJsonMerge"
                                                         :consumes ["application/merge-patch+json"]
                                                         :x-kubernetes-action "patch/json-merge"}
                                      :patch/strategic {:parameters [{:name "body"
                                                                      :in "body"
-                                                                     :schema {}}]
+                                                                     :schema 'schema}]
                                                        :operationId "PatchCoreV1ResourceStrategicMerge"
                                                        :consumes ["application/strategic-merge-patch+json"]
                                                        :x-kubernetes-action "patch/strategic"}
                                      :apply/server {:parameters [{:name "body"
                                                                   :in "body"
-                                                                  :schema {}}]
+                                                                  :schema 'schema}]
                                                     :operationId "PatchCoreV1ResourceApplyServerSide"
                                                     :consumes ["application/apply-patch+yaml"]
                                                     :x-kubernetes-action "apply/server"}}}}
                 (swagger/add-patch-routes
-                 {:paths {"/foo/bar" {:patch {:operationId "PatchCoreV1Resource"
+                  {:paths {"/foo/bar" {:put {:parameters [{:name "body"
+                                                            :in "body"
+                                                            :schema 'schema}]
+                                             :x-kubernetes-action "update"}
+                                       :patch {:operationId "PatchCoreV1Resource"
                                               :parameters [{:name "body"
                                                             :in "body"
                                                             :schema 'broken}]}}}})))))


### PR DESCRIPTION
## Context

Currently, the body schema for the `:patch` action is empty, which doesn't allow any valid patch to be done. This happens because the swagger schema itself it's configured simply with the following definition:
```json
    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
      "type": "object"
    },
```

## What changed

Kubernetes has 4 types of patches, depending on the header "Content-Type" passed: 
```
application/json-patch+json
application/merge-patch+json
application/strategic-merge-patch+json
application/apply-patch+yaml
```

So this PR changes the swagger schema dynamically to generate the following new actions:
```clojure
:patch/json
:patch/json-merge
:patch/strategic
:apply/server
```

So the `(k8s/explore client :ConfigMap)` looks like this:
```clojure
[:ConfigMap
 [:list "list or watch objects of kind ConfigMap"]
 [:create "create a ConfigMap"]
 [:deletecollection "delete collection of ConfigMap"]
 [:list-all "list or watch objects of kind ConfigMap"]
 [:get "read the specified ConfigMap"]
 [:update "replace the specified ConfigMap"]
 [:delete "delete a ConfigMap"]
 [:patch/json "update the specified ConfigMap using RFC6902"]
 [:patch/strategic "update the specified ConfigMap using a smart strategy"]
 [:patch/json-merge "update the specified ConfigMap using RFC7286"]
 [:apply/server
  "create or update the specified ConfigMap using server side apply"]]
```