### PR TITLE
Allow customize exceptions

### DIFF
--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -10,6 +10,10 @@
             [martian.httpkit :as martian-httpkit]
             martian.swagger))
 
+(defn default-interceptors [opts]
+  [(interceptors.auth/new opts)
+   interceptors.raise/interceptor])
+
 (defn client
   "Creates a Kubernetes Client compliant with martian api and its helpers
 
@@ -34,9 +38,7 @@
            {:basic-auth {:username \"admin\"
                          :password \"1234\"}})"
   [host opts]
-  (let [interceptors (concat [(interceptors.raise/new opts)
-                              (interceptors.auth/new opts)]
-                             (:interceptors opts)
+  (let [interceptors (concat (:interceptors opts (default-interceptors opts))
                              martian-httpkit/default-interceptors)
         k8s          (internals.client/pascal-case-routes
                       (martian/bootstrap-swagger host
@@ -123,4 +125,3 @@
     schemas"
   [k8s params]
   (martian/explore k8s (internals.client/find-preferred-route k8s (dissoc params :request))))
-

--- a/src/kubernetes_api/interceptors/raise.clj
+++ b/src/kubernetes_api/interceptors/raise.clj
@@ -49,7 +49,7 @@
     (status-error? (:status response)) (raise-exception response)
     :else (:body response)))
 
-(defn new [_]
+(def interceptor
   {:name  ::raise
    :leave (fn [{:keys [request response] :as _context}]
             (with-meta {:response (check-response response)}

--- a/test/kubernetes_api/extensions/custom_resource_definition_test.clj
+++ b/test/kubernetes_api/extensions/custom_resource_definition_test.clj
@@ -1,7 +1,7 @@
 (ns kubernetes-api.extensions.custom-resource-definition-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [kubernetes-api.extensions.custom-resource-definition :as crd]
-            [matcher-combinators.test]))
+            [matcher-combinators.test :refer [match?]]))
 
 (deftest new-route-name-test
   (testing "list"

--- a/test/kubernetes_api/interceptors/auth_test.clj
+++ b/test/kubernetes_api/interceptors/auth_test.clj
@@ -1,9 +1,8 @@
 (ns kubernetes-api.interceptors.auth-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [kubernetes-api.interceptors.auth :as interceptors.auth]
-            [matcher-combinators.matchers :as m]
-            [matcher-combinators.test]
-            [mockfn.core :refer [providing]]))
+            [matcher-combinators.test :refer [match?]]
+            [mockfn.test :refer [providing]]))
 
 (deftest auth-test
   (testing "request with basic-auth"

--- a/test/kubernetes_api/interceptors/raise_test.clj
+++ b/test/kubernetes_api/interceptors/raise_test.clj
@@ -4,7 +4,7 @@
             [matcher-combinators.test :refer [match? thrown-match?]]))
 
 (deftest raise-test
-  (let [{:keys [leave]} (interceptors.raise/new {})]
+  (let [{:keys [leave]} interceptors.raise/interceptor]
     (testing "should raise the body to be the response on 2xx status"
       (is (match?
            {:response {:my :body}}

--- a/test/kubernetes_api/interceptors/raise_test.clj
+++ b/test/kubernetes_api/interceptors/raise_test.clj
@@ -1,7 +1,7 @@
 (ns kubernetes-api.interceptors.raise-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [kubernetes-api.interceptors.raise :as interceptors.raise]
-            [matcher-combinators.test]))
+            [matcher-combinators.test :refer [match? thrown-match?]]))
 
 (deftest raise-test
   (let [{:keys [leave]} (interceptors.raise/new {})]

--- a/test/kubernetes_api/internals/client_test.clj
+++ b/test/kubernetes_api/internals/client_test.clj
@@ -1,6 +1,7 @@
 (ns kubernetes-api.internals.client-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [kubernetes-api.internals.client :as internals.client]
+            [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as m]))
 
 (deftest pascal-case-routes-test

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -1,5 +1,5 @@
 (ns kubernetes-api.swagger-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [kubernetes-api.swagger :as swagger]))
 
 (deftest remove-watch-endpoints-test


### PR DESCRIPTION
## Context

We have some problems with the `raise` interceptor that it, in conjunction with the way `martian` defines the interceptor stack, will always log the exception on `stderr`.

Explaining in more detail:
- The `interceptors.raise` code will [throw if there is a non 200 status](https://github.com/nubank/k8s-api/blob/master/src/kubernetes_api/interceptors/raise.clj#L39-L42).
- That exception is thrown over the `tripod` stack and will be raised to the [tripod.context/execute call](https://github.com/frankiesardo/tripod/blob/master/src/tripod/context.cljc#L220-L222).
- Martian executes the interceptor stack using the [callback from http-kit.client/request](https://github.com/oliyh/martian/blob/0.1.12/httpkit/src/martian/httpkit.clj#L26-L28)
- [Any exception thrown there will be logged to stderr by httpkit](https://github.com/http-kit/http-kit/blob/master/src/org/httpkit/client.clj#L272-L276), which seems to me like a problem and should not be happening, thus there is a ticket about it https://github.com/http-kit/http-kit/issues/518.

The proposed solution by the developers is to catch such exceptions before, which seems to be a good option, considering that what we are doing on OUR code is to use http status as control flow and exceptions are not actually a good driver for this.

The main issue here, is that with these exceptions always being logged on `stderr` causes our monitoring to be hectic as we should keep monitoring for problems there and ignoring stack traces seems to be dangerous in this situation.

## Impact

I've checked the usages of the [kubernetes-api.core](https://github.com/search?q=org%3Anubank+kubernetes-api.core+language%3AClojure+NOT+repo%3Anubank%2Fk8s-api+path%3A%2F%5Esrc%5C%2F%2F&type=code) namespace, and there does not seems to be any usage of the `:interceptor` parameter, even it being a breaking change, it will not have impact on our codebase.

## Changelog
- Remove usage o `:refer :all` in tests
- Allow for the `:interceptor` parameter to override all the default interceptors of the client.