### PR TITLE
Bump martian and add openapi config to disable discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.0
+- Bump martian to version 0.1.26 to get fix about [parameters spec](https://github.com/oliyh/martian/pull/196)
+- Add openapi configuration to disable automatic discovery (see README.md)
+
 ## 0.2.1
 - Add support for JSON Patch, JSON Merge, Strategic Merge Patch and Server-Side
 Apply requests.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ We had a good experience with
 
 ### clojure.deps
 ```clojure
-{:deps {nubank/k8s-api {:mvn/version "0.1.2"}}}
+{:deps {nubank/k8s-api {:mvn/version "0.3.0"}}}
 ```
 
 ### Leiningen
 ```clojure
-[nubank/k8s-api "0.1.2"]
+[nubank/k8s-api "0.3.0"]
 ```
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ You can also define client certificates
                                          :client-key  "/some/path/client-java.key"}))
 ```
 
+#### OpenAPI config
+It's possible but NOT RECOMMENDED to disable the OpenAPI specification discovery. This will prevent requests to
+`/openapi/...` endpoints and use the specification from the resources folder. This specification has no guarantees in
+ terms of versioning, so it will be outdated.
+```clojure
+(def k8s (k8s/client "http://some.host" {:token "..." 
+                                         :openapi {:discovery :disabled}}))
+```
+
 ### Discover
 You can list all operations with
 ```clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.2.1-SNAPSHOT"
+(defproject nubank/k8s-api "0.3.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
             [lein-nsorg "0.2.0"]]
   :cljfmt {:indents {providing [[:inner 0]]}}
   :dependencies [[org.clojure/clojure "1.11.0"]
-                 [com.github.oliyh/martian "0.1.26-SNAPSHOT"]
-                 [com.github.oliyh/martian-httpkit "0.1.25"]
+                 [com.github.oliyh/martian "0.1.26"]
+                 [com.github.oliyh/martian-httpkit "0.1.26"]
                  [less-awful-ssl "1.0.6"]]
   :main ^:skip-aot kubernetes-api.core
   :resource-paths ["resources"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.2.1"
+(defproject nubank/k8s-api "0.2.1-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -7,11 +7,10 @@
             [lein-kibit "0.1.6"]
             [lein-nsorg "0.2.0"]]
   :cljfmt {:indents {providing [[:inner 0]]}}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [martian "0.1.12-20191222.142233-2"]
-                 [martian-httpkit "0.1.11"]
-                 [io.forward/yaml "1.0.9"]
-                 [less-awful-ssl "1.0.4"]]
+  :dependencies [[org.clojure/clojure "1.11.0"]
+                 [com.github.oliyh/martian "0.1.26-SNAPSHOT"]
+                 [com.github.oliyh/martian-httpkit "0.1.25"]
+                 [less-awful-ssl "1.0.6"]]
   :main ^:skip-aot kubernetes-api.core
   :resource-paths ["resources"]
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.3.0-SNAPSHOT"
+(defproject nubank/k8s-api "0.3.0"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -166,6 +166,10 @@
     s
     (keyword s)))
 
+(defn openapi-discovery-enabled?
+  [opts]
+  (not= :disabled (get-in opts [:openapi :discovery])))
+
 (defn read []
   (customized (-> (io/resource "kubernetes_api/swagger.json")
                   io/input-stream
@@ -182,6 +186,7 @@
 
 (defn from-api [api-root opts]
   (try
-    (customized (from-api* api-root opts))
+    (when (openapi-discovery-enabled? opts)
+      (customized (from-api* api-root opts)))
     (catch Exception _
       nil)))


### PR DESCRIPTION
- Bump martian to version 0.1.26
  https://github.com/oliyh/martian/pull/196
  
- Add openapi config to disable discovery
  The OpenAPI specification discovery can be disabled, but it is not recommended. This will stop requests to `/openapi/...` endpoints and instead use a specification from the `resources` folder. However, this specification may not be up-to-date in terms of versioning.
  
  ```clojure
  (def k8s (k8s/client "http://some.host" {:token "..." 
                                           :openapi {:discovery :disabled}}))
  ```