### PR TITLE
Update extend-client to use apiextensions/v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.4.0
+- Update unreleased extend-client function to use apiextensions/v1, since apiextensions/v1beta1 was deleted in newer versions of kubernetes
+- Refactor extend-client code to simplify it
+
 ## 0.3.0
 - Bump martian to version 0.1.26 to get fix about [parameters spec](https://github.com/oliyh/martian/pull/196)
 - Add openapi configuration to disable automatic discovery (see README.md)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.3.0"
+(defproject nubank/k8s-api "0.4.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.4.0-SNAPSHOT"
+(defproject nubank/k8s-api "0.4.0"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.4.0"
+(defproject nubank/k8s-api "0.5.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -80,7 +80,7 @@
   (let [api-resources (internals.martian/response-for k8s :GetArbitraryApiResources
                                                       {:api     api
                                                        :version version})
-        crds (internals.martian/response-for k8s :ListApiextensionsV1beta1CustomResourceDefinition)]
+        crds (internals.martian/response-for k8s :ListApiextensionsV1CustomResourceDefinition)]
     (internals.client/pascal-case-routes
      (update k8s
              :handlers #(concat % (martian.swagger/swagger->handlers


### PR DESCRIPTION
- Update unreleased `extend-client` function to use apiextensions/v1, since apiextensions/v1beta1 was deleted in newer versions of kubernetes
- Refactor `extend-client` code to simplify it