### PR TITLE
Filter paths from api specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,26 @@ You can also define client certificates
 ```
 
 #### OpenAPI config
+
+##### Discovery
+
 It's possible but NOT RECOMMENDED to disable the OpenAPI specification discovery. This will prevent requests to
 `/openapi/...` endpoints and use the specification from the resources folder. This specification has no guarantees in
  terms of versioning, so it will be outdated.
 ```clojure
-(def k8s (k8s/client "http://some.host" {:token "..." 
+(def k8s (k8s/client "http://some.host" {:token "..."
                                          :openapi {:discovery :disabled}}))
+```
+
+##### Filter paths from api
+
+You can filter the paths from the OpenAPI specification. This is useful when you want to use a specific version of the
+api, or when you want to use a specific group of resources.
+
+```clojure
+(def k8s (k8s/client "http://some.host" {:token "..."
+                                         :openapi {:api "some.api"
+                                                   :version "v1"}}))
 ```
 
 ### Discover

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ api, or when you want to use a specific group of resources.
 
 ```clojure
 (def k8s (k8s/client "http://some.host" {:token "..."
-                                         :openapi {:api "some.api"
-                                                   :version "v1"}}))
+                                         :openapi {:apis ["some.api/v1alpha1", "another.api"]}}))
 ```
 
 ### Discover

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.5.0-SNAPSHOT"
+(defproject nubank/k8s-api "0.5.1-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "0.3.0"
+(defproject nubank/k8s-api "0.5.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -17,5 +17,6 @@
   :aliases {"lint"     ["do" ["cljfmt" "check"] ["nsorg"] ["kibit"]]
             "lint-fix" ["do" ["cljfmt" "fix"] ["nsorg" "--replace"] ["kibit" "--replace"]]}
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[nubank/matcher-combinators "3.8.5"]
+             :dev {:resource-paths ["test/kubernetes_api/resources"]
+                   :dependencies [[nubank/matcher-combinators "3.8.5"]
                                   [nubank/mockfn "0.7.0"]]}})

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -35,6 +35,7 @@
   [OpenAPI]
   :openapi/:discovery - :disabled to avoid fetching openapi schema from k8s
   :openapi/:apis - a list of api groups to fetch the schema from
+                   default is in kubernetes-api.swagger/default-apis
 
   Example 1:
   (client \"https://kubernetes.docker.internal:6443\"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -34,13 +34,17 @@
 
   [OpenAPI]
   :openapi/:discovery - :disabled to avoid fetching openapi schema from k8s
-  :openapi/:api - the api group to fetch the schema from
-  :openapi/:version - the version of the api group to fetch the schema from
+  :openapi/:apis - a list of api groups to fetch the schema from
 
-  Example:
+  Example 1:
   (client \"https://kubernetes.docker.internal:6443\"
            {:basic-auth {:username \"admin\"
-                         :password \"1234\"}})"
+                         :password \"1234\"}})
+  Example 2:
+  (client \"https://kubernetes.docker.internal:6443\"
+           {:basic-auth {:username \"admin\"
+                         :password \"1234\"}
+            :openapi {:apis [\"some.api/v1alpha1\", \"another.api\"]}})"
   [host opts]
   (let [interceptors (concat [(interceptors.raise/new opts)
                               (interceptors.auth/new opts)]
@@ -52,7 +56,7 @@
         k8s          (internals.client/transform
                       (martian/bootstrap-swagger host
                                                  (or (swagger/from-api host opts)
-                                                     (swagger/read))
+                                                     (swagger/read opts))
                                                  {:interceptors interceptors}))]
     (assoc k8s
            ::api-group-list (internals.martian/response-for k8s :GetApiVersions)

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -32,6 +32,11 @@
   [Custom]
   :interceptors - additional interceptors to the martian's client
 
+  [OpenAPI]
+  :openapi/:discovery - :disabled to avoid fetching openapi schema from k8s
+  :openapi/:api - the api group to fetch the schema from
+  :openapi/:version - the version of the api group to fetch the schema from
+
   Example:
   (client \"https://kubernetes.docker.internal:6443\"
            {:basic-auth {:username \"admin\"

--- a/src/kubernetes_api/swagger.clj
+++ b/src/kubernetes_api/swagger.clj
@@ -154,11 +154,15 @@
    "/api/" (get-in paths ["/api/"])})
 
 (defn filter-api
-  "Returns the paths that starts with the given api and version
-   e.g. /apis/{api}/..."
+  "Returns the paths that start with the given api and version
+   e.g. /apis/{api}/...; /api/{api}/...; /{api}/..."
   [api paths]
-  (into {}
-        (filter #(string/starts-with? (first %) (str "/apis/" api)) paths)))
+  (let [api-paths [(str "/apis/" api)
+                   (str "/api/" api)
+                   (str "/" api)]
+        starts-with-api? (fn [path]
+                           (some #(string/starts-with? path %) api-paths))]
+    (into {} (filter (comp starts-with-api? first) paths))))
 
 (defn from-apis
   "Returns the default paths and the paths for the given apis"

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -99,3 +99,90 @@
                                   {:Movie {:type       "object"
                                            :properties {:name {:type "string"}}}}
                                   {"/movies/{id}" {:get {:response-schemas {"200" {:$ref "#/definitions/Movie"}}}}}))))
+
+(deftest default-paths-test
+  (testing "returns the default paths /apis/ and /api/"
+    (is (= {"/apis/" {}
+            "/api/"  {}}
+           (swagger/default-paths {"/apis/"        {}
+                                   "/apis/foo/bar" {}
+                                   "/api/"         {}})))
+    (is (= {"/apis/" {}
+            "/api/"  nil}
+           (swagger/default-paths {"/apis/"        {}
+                                   "/apis/foo/bar" {}})))))
+
+(deftest filter-api-version-test
+  (testing "returns the paths from the api version specified"
+    (is (=  {"/apis/foo.bar/v1" {}}
+         (swagger/filter-api-version "foo.bar" "v1"
+                                     {"/apis/"           {}
+                                      "/foo.bar/v1"      {}
+                                      "/apis/foo/bar"    {}
+                                      "/apis/foo.bar/v1" {}}))))
+  (is (empty? (swagger/filter-api-version "foo.bar" "v2"
+                                          {"/apis/"           {}
+                                           "/api/"            {}
+                                           "/apis/foo/bar"    {}
+                                           "/apis/foo.bar/v1" {}}))))
+
+(deftest from-api-version-test
+  (testing "returns the paths from the api version specified and the default paths"
+    (is (=  {"/apis/"           {}
+             "/api/"            {}
+             "/apis/foo.bar/v1" {}}
+         (swagger/from-api-version "foo.bar" "v1"
+                                   {"/apis/"           {}
+                                    "/api/"            {}
+                                    "/apis/foo/bar"    {}
+                                    "/apis/foo.bar/v1" {}})))
+  (is (= {"/apis/" {}
+          "/api/"  {}}
+         (swagger/from-api-version "foo.bar" "v2"
+                                   {"/apis/"           {}
+                                    "/api/"            {}
+                                    "/apis/foo/bar"    {}
+                                    "/apis/foo.bar/v1" {}})))))
+
+(deftest filter-by-api-version?-test
+  (testing "Returns true if the api and version are present"
+    (is (true? (swagger/filter-by-api-version? "foo.bar" "v1"))))
+
+  (testing "Returns false if one of the api or version is empty"
+    (is (false? (swagger/filter-by-api-version? "" "v1")))
+    (is (false? (swagger/filter-by-api-version? "foo.bar" ""))))
+
+  (testing "Returns false if keys are missing"
+    (is (false? (swagger/filter-by-api-version? nil "v1")))
+    (is (false? (swagger/filter-by-api-version? "foo.bar" nil)))
+    (is (false? (swagger/filter-by-api-version? "" "")))
+    (is (false? (swagger/filter-by-api-version? nil nil)))))
+
+(deftest filter-paths-test
+  (testing "filter the paths for the api and version specified"
+    (is (= {:paths {"/apis/"           {}
+                    "/api/"            {}
+                    "/apis/foo.bar/v1" {}}}
+           (swagger/filter-paths {:paths {"/apis/"           {}
+                                          "/api/"            {}
+                                          "/apis/foo/bar"    {}
+                                          "/apis/foo.bar/v1" {}}}
+                                 "foo.bar"
+                                 "v1"))))
+  (testing "do not update paths if api or version not found"
+    (is (= {:paths {"/apis/"           {}
+                    "/api/"            {}}}
+           (swagger/filter-paths {:paths {"/apis/"           {}
+                                          "/api/"            {}
+                                          "/apis/foo/bar"    {}
+                                          "/apis/foo.bar/v1" {}}}
+                                 "bar"
+                                 "v2"))))
+
+  (testing "returns the default paths if api or version is missing"
+    (is (= {:paths {"/apis/" {}
+                    "/api/"  {}}}
+           (swagger/filter-paths {:paths {"/apis/"           {}
+                                          "/api/"            {}
+                                          "/apis/foo/bar"    {}
+                                          "/apis/foo.bar/v1" {}}} nil nil)))))

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -1,7 +1,7 @@
 (ns kubernetes-api.swagger-test
   (:require [clojure.test :refer :all]
-            [matcher-combinators.test :refer [match?]]
-            [kubernetes-api.swagger :as swagger]))
+            [kubernetes-api.swagger :as swagger]
+            [matcher-combinators.test :refer [match?]]))
 
 (deftest remove-watch-endpoints-test
   (is (= {:paths {"/foo/bar" 'irrelevant
@@ -114,25 +114,42 @@
 
 (deftest filter-api-test
   (testing "returns the paths from the api version specified"
-    (is (= {"/apis/foo.bar/v1" {}}
+    (is (= {"/apis/foo.bar/v1" {}
+            "/foo.bar/v1"      {}}
            (swagger/filter-api "foo.bar/v1"
                                {"/apis/"           {}
                                 "/foo.bar/v1"      {}
                                 "/apis/foo/bar"    {}
                                 "/apis/foo.bar/v1" {}
                                 "/apis/foo.bar/v2" {}})))
-    (is (= {"/apis/foo.bar/v1" {}
+    (is (= {"/foo.bar/v1"      {}
+            "/apis/foo.bar/v1" {}
             "/apis/foo.bar/v2" {}}
            (swagger/filter-api "foo.bar"
                                {"/apis/"           {}
                                 "/foo.bar/v1"      {}
-                                "/apis/foo.bar/v1"  {}
+                                "/apis/foo.bar/v1" {}
                                 "/apis/foo.bar/v2" {}})))
     (is (empty? (swagger/filter-api "foo.bar/v2"
                                     {"/apis/"           {}
                                      "/api/"            {}
                                      "/apis/foo/bar"    {}
-                                     "/apis/foo.bar/v1" {}})))))
+                                     "/apis/foo.bar/v1" {}})))
+    (is (= {"/api/v1" {}}
+           (swagger/filter-api "v1"
+                               {"/api/v1"          {}
+                                "/foo.bar/v1"      {}
+                                "/apis/foo.bar/v1" {}
+                                "/apis/foo.bar/v2" {}})))
+    (is (= {"/api/v1"  {}
+            "/apis/v1" {}
+            "/v1"      {}}
+           (swagger/filter-api "v1"
+                               {"/api/v1"          {}
+                                "/apis/v1"         {}
+                                "/v1"              {}
+                                "/apis/foo.bar/v1" {}
+                                "/apis/foo.bar/v2" {}})))))
 
 (deftest from-apis-test
   (testing "returns the paths from the api version specified and the default paths"

--- a/test/kubernetes_api/swagger_test.clj
+++ b/test/kubernetes_api/swagger_test.clj
@@ -149,7 +149,11 @@
                                 "/apis/v1"         {}
                                 "/v1"              {}
                                 "/apis/foo.bar/v1" {}
-                                "/apis/foo.bar/v2" {}})))))
+                                "/apis/foo.bar/v2" {}})))
+
+    (is (= {"/api/v1" {}}
+           (swagger/filter-api "/api"
+                               {"/api/v1" {}})))))
 
 (deftest from-apis-test
   (testing "returns the paths from the api version specified and the default paths"
@@ -213,4 +217,13 @@
            (swagger/filter-paths {:paths {"/apis/"           {}
                                           "/api/"            {}
                                           "/apis/foo/bar"    {}
-                                          "/apis/foo.bar/v1" {}}} [])))))
+                                          "/apis/foo.bar/v1" {}}} []))))
+
+  (testing "Returns default apis"
+    (is (match? {:paths {"/api/v1/configmaps"        {}
+                         "/apis/apps/v1/deployments" {}
+                         "/logs/"                    {}
+                         "/openid/v1/jwks/"          {}
+                         "/version/"                 {}}}
+         (-> (swagger/parse-swagger-file "test_swagger.json")
+             (swagger/filter-paths swagger/default-apis))))))


### PR DESCRIPTION
Filter some paths from the OpenAPI specification. 
This is useful when you want to use a specific version of the API, or when you want to use a specific group of resources.

```clojure
(def k8s (k8s/client "http://some.host" {:token "..."
                                         :openapi {:apis ["some.api/v1alpha1", "another.api"]}}))
```

Another use case is to use a group of resources that aren't custom resource definition.