### PR TITLE
Add support for base64 secrets and settings self-signed CA certificate

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
   :dependencies [[org.clojure/clojure "1.11.0"]
                  [com.github.oliyh/martian "0.1.26"]
                  [com.github.oliyh/martian-httpkit "0.1.26"]
-                 [less-awful-ssl "1.0.6"]]
+                 [less-awful-ssl "1.0.6"]
+                 [http-kit/http-kit "2.8.0-alpha3"]]
   :main ^:skip-aot kubernetes-api.core
   :resource-paths ["resources"]
   :target-path "target/%s"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -27,6 +27,12 @@
                token
   :client-cert/:ca-cert/:client-key - string filepath indicating certificates
                                        and key files to configure client cert.
+  :certificate-authority-data - a base64 encoded string with the certificate
+                                 authority data
+  :client-certificate-data - a base64 encoded string with the client certificate
+                             alternative to :client-cert
+  :client-key-data - a base64 encoded string with the client key alternative
+                     to :client-key
   :insecure? - ignore self-signed server certificates
 
   [Custom]

--- a/src/kubernetes_api/interceptors/auth.clj
+++ b/src/kubernetes_api/interceptors/auth.clj
@@ -23,7 +23,11 @@
 
 (defn request-auth-params [{:keys [token-fn insecure?] :as opts}]
   (merge
-   {:insecure? (or insecure? false)}
+    {:insecure? (or insecure? false)
+     :sslengine (.createSSLEngine (doto (javax.net.ssl.SSLContext/getInstance "TLSv1.2")
+                   (.init nil
+                          (into-array javax.net.ssl.TrustManager [(less.awful.ssl/trust-manager (less.awful.ssl/trust-store "/Users/rafael.leal/.kube/ca-br-prod-s9-green.crt"))])
+                          nil)))}
    (cond
      (basic-auth? opts) {:basic-auth (basic-auth opts)}
      (token? opts) {:oauth-token (:token opts)}

--- a/src/kubernetes_api/interceptors/auth/ssl.clj
+++ b/src/kubernetes_api/interceptors/auth/ssl.clj
@@ -26,10 +26,7 @@
     last
     ssl/base64->binary
     PKCS8EncodedKeySpec.
-    (.generatePrivate ssl/rsa-key-factory))
-    #_
-  (->> (PKCS8EncodedKeySpec. (ssl/base64->binary base64-private-key)) 
-       (.generatePrivate ssl/rsa-key-factory)))
+    (.generatePrivate ssl/rsa-key-factory)))
 
 (defn private-key [{:keys [key key-data]}]
   (cond

--- a/src/kubernetes_api/interceptors/auth/ssl.clj
+++ b/src/kubernetes_api/interceptors/auth/ssl.clj
@@ -1,0 +1,84 @@
+(ns kubernetes-api.interceptors.auth.ssl
+  (:require [less.awful.ssl :as ssl])
+  (:import (java.io ByteArrayInputStream)
+           (java.security KeyStore)
+           (java.security.spec PKCS8EncodedKeySpec)
+           (java.security.cert Certificate)
+           (javax.net.ssl SSLContext
+                          TrustManager
+                          KeyManager)))
+
+(defn load-certificate ^Certificate [{:keys [cert-file cert-data]}]
+  (cond
+    (some? cert-file) (ssl/load-certificate cert-file)
+    (some? cert-data) (with-open [stream (ByteArrayInputStream. (ssl/base64->binary cert-data))]
+                        (.generateCertificate ssl/x509-cert-factory stream))))
+
+(defn trust-store [cert]
+  (doto (KeyStore/getInstance "JKS")
+    (.load nil nil)
+    (.setCertificateEntry "cacert" (load-certificate cert))))
+
+(defn base64->private-key
+  [base64-private-key]
+(->> (String. (ssl/base64->binary base64-private-key) java.nio.charset.StandardCharsets/UTF_8)
+    (re-find #"(?ms)^-----BEGIN ?.*? PRIVATE KEY-----$(.+)^-----END ?.*? PRIVATE KEY-----$")
+    last
+    ssl/base64->binary
+    PKCS8EncodedKeySpec.
+    (.generatePrivate ssl/rsa-key-factory))
+    #_
+  (->> (PKCS8EncodedKeySpec. (ssl/base64->binary base64-private-key)) 
+       (.generatePrivate ssl/rsa-key-factory)))
+
+(defn private-key [{:keys [key key-data]}]
+  (cond
+    (some? key)      (ssl/private-key key)
+    (some? key-data) (base64->private-key key-data)))
+
+(defn ^"[Ljava.security.cert.Certificate;" load-certificate-chain
+  [{:keys [cert-file cert-data]}]
+  (cond
+    (some? cert-file) (ssl/load-certificate-chain cert-file)
+    (some? cert-data) (with-open [stream (ByteArrayInputStream. (ssl/base64->binary cert-data))]
+                        (let [^"[Ljava.security.cert.Certificate;" ar (make-array Certificate 0)] 
+                          (.toArray (.generateCertificates ssl/x509-cert-factory stream) ar)))))
+
+(defn key-store
+  [key cert]
+  (let [pk     (private-key key)
+        certs   (load-certificate-chain cert)]
+    (doto (KeyStore/getInstance (KeyStore/getDefaultType))
+      (.load nil nil)
+      ; alias, private key, password, certificate chain
+      (.setKeyEntry "cert" pk ssl/key-store-password certs))))
+
+(defn client-certs->ssl-context ^SSLContext
+  [client-key client-cert ca-cert]
+   (let [key-manager (ssl/key-manager (key-store client-key client-cert))
+         trust-manager (ssl/trust-manager (trust-store ca-cert))]
+     (doto (SSLContext/getInstance "TLSv1.2")
+       (.init (into-array KeyManager [key-manager])
+              (into-array TrustManager [trust-manager])
+              nil))))
+
+(defn client-certs->ssl-engine
+  [{:keys [ca-cert certificate-authority-data client-cert client-certificate-data client-key client-key-data]}]
+  (let [key {:key client-key
+             :key-data client-key-data}
+        cert {:cert-file client-cert
+              :cert-data client-certificate-data}
+        ca-crt {:cert-file ca-cert
+                :cert-data certificate-authority-data}]
+    (ssl/ssl-context->engine
+     (client-certs->ssl-context key cert ca-crt))))
+
+(defn ca-cert->ssl-context [cert]
+  (doto (SSLContext/getInstance "TLSv1.2")
+       (.init nil (into-array TrustManager [(less.awful.ssl/trust-manager (trust-store cert))]) nil)))
+
+(defn ca-cert->ssl-engine
+  [{:keys [ca-cert certificate-authority-data]}]
+  (ssl/ssl-context->engine
+   (ca-cert->ssl-context {:cert-file ca-cert
+                          :cert-data certificate-authority-data})))

--- a/test/kubernetes_api/interceptors/auth_test.clj
+++ b/test/kubernetes_api/interceptors/auth_test.clj
@@ -1,9 +1,10 @@
 (ns kubernetes-api.interceptors.auth-test
   (:require [clojure.test :refer :all]
             [kubernetes-api.interceptors.auth :as interceptors.auth]
-            [matcher-combinators.matchers :as m]
+            [kubernetes-api.interceptors.auth.ssl :as auth.ssl]
+            [matcher-combinators.standalone :refer [match?]]
             [matcher-combinators.test]
-            [mockfn.core :refer [providing]]))
+            [mockfn.macros]))
 
 (deftest auth-test
   (testing "request with basic-auth"
@@ -11,16 +12,24 @@
                 ((:enter (interceptors.auth/new {:username "floki"
                                                  :password "freya1234"})) {}))))
   (testing "request with client certificate"
-    (providing [(#'interceptors.auth/new-ssl-engine {:client-cert "/some/client.crt"
-                                                     :client-key  "/some/client.key"
-                                                     :ca-cert     "/some/ca-cert.crt"}) 'SSLEngine]
-      (is (match? {:request {:sslengine #(= 'SSLEngine %)}}
-                  ((:enter (interceptors.auth/new {:client-cert "/some/client.crt"
-                                                   :client-key  "/some/client.key"
-                                                   :ca-cert     "/some/ca-cert.crt"})) {})))))
+    (mockfn.macros/providing
+     [(auth.ssl/client-certs->ssl-engine {:client-cert "/some/client.crt"
+                                          :client-key  "/some/client.key"
+                                          :ca-cert     "/some/ca-cert.crt"}) 'SSLEngine]
+     (is (match? {:request {:sslengine #(= 'SSLEngine %)}}
+                 ((:enter (interceptors.auth/new {:client-cert "/some/client.crt"
+                                                  :client-key  "/some/client.key"
+                                                  :ca-cert     "/some/ca-cert.crt"})) {})))))
   (testing "request with token"
     (is (match? {:request {:oauth-token "TOKEN"}}
                 ((:enter (interceptors.auth/new {:token "TOKEN"})) {}))))
   (testing "request with token-fn"
     (is (match? {:request {:oauth-token "TOKEN"}}
-                ((:enter (interceptors.auth/new {:token-fn (constantly "TOKEN")})) {})))))
+                ((:enter (interceptors.auth/new {:token-fn (constantly "TOKEN")})) {}))))
+  (testing "request with token and ca-certificate"
+    (mockfn.macros/providing
+     [(auth.ssl/ca-cert->ssl-engine (match? {:ca-cert "/some/ca-cert.crt"})) 'SSLEngine]
+     (is (match? {:request {:sslengine #(= 'SSLEngine %)
+                            :oauth-token "TOKEN"}}
+                 ((:enter (interceptors.auth/new {:token   "TOKEN"
+                                                  :ca-cert "/some/ca-cert.crt"})) {}))))))


### PR DESCRIPTION
## Context

Right now, you don't have the option of using self-signed certificates when using `token`, `token-fn` or `basic-auth` authentication. You can only set the CA certificate if you set also the client certificates.

## Feature

- Enable users to set either `:ca-cert` (filename) or `:certificate-authority-data` (base64 encoded string) alongside all other authentication methods.

Example:
```clojure
(k8s/client url {:token token :ca-cert "/root/.kube/some-ca.crt"})
```

- Allow setting base64 encoded secrets alternatives.
Example:
```clojure
(k8s/client url {:certificate-authority-data (get-ca-from-eks-api ...)
                 :client-certificate-data    (get-from-secret-providers ...)
                 :client-key-data            (get-from-secret-providers ...)}
```

You can mix and match base64-encoded secrets (`:certificate-authority-data`, `client-certificate-data` and `:client-key-data`) and the existing file configurations (`:ca-cert`, `:client-cert`, and `:client-key`)