### PR TITLE
Extract the base64 data between the header and footer of the certificate-authority-data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "1.1.0-SNAPSHOT"
+(defproject nubank/k8s-api "1.0.1-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/test/kubernetes_api/interceptors/auth_test.clj
+++ b/test/kubernetes_api/interceptors/auth_test.clj
@@ -4,7 +4,8 @@
             [kubernetes-api.interceptors.auth.ssl :as auth.ssl]
             [matcher-combinators.standalone :refer [match?]]
             [matcher-combinators.test]
-            [mockfn.macros]))
+            [mockfn.macros]
+            [clojure.string :as string]))
 
 (deftest auth-test
   (testing "request with basic-auth"
@@ -33,3 +34,15 @@
                             :oauth-token "TOKEN"}}
                  ((:enter (interceptors.auth/new {:token   "TOKEN"
                                                   :ca-cert "/some/ca-cert.crt"})) {}))))))
+
+(deftest extract-cert-data-test
+  (testing "should extract data between header and footer"
+    (is (= "\nY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGEK\n"
+           (auth.ssl/extract-cert-data "-----BEGIN CERTIFICATE-----\nY2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGEK\n-----END CERTIFICATE-----"))))
+
+  (testing "should keep same data if no header and footer"
+    (is (= "Y2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGEK"
+           (auth.ssl/extract-cert-data "Y2VydGlmaWNhdGUtYXV0aG9yaXR5LWRhdGEK"))))
+
+  (testing "no op if empty string"
+    (is (string/blank? (auth.ssl/extract-cert-data "")))))


### PR DESCRIPTION
### Context

By sending the content of a certificate authority file, the client is not created and fails with the following exception:

```
Execution error (IOException) at sun.security.provider.X509Factory/engineGenerateCertificate (X509Factory.java:111).
Empty input
```

This PR aims to extract the base64 data between the header and footer of the certificate-authority-data argument.
