### PR TITLE
Dependency updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,15 @@
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :plugins [[lein-cljfmt "0.5.7"]
-            [lein-kibit "0.1.6"]
-            [lein-nsorg "0.2.0"]]
+  :plugins [[lein-cljfmt "0.9.2"]
+            [lein-kibit "0.1.11"]
+            [lein-nsorg "0.3.0"]]
   :cljfmt {:indents {providing [[:inner 0]]}}
-  :dependencies [[org.clojure/clojure "1.11.0"]
-                 [com.github.oliyh/martian "0.1.26"]
-                 [com.github.oliyh/martian-httpkit "0.1.26"]
-                 [less-awful-ssl "1.0.6"]
-                 [http-kit/http-kit "2.8.0-alpha3"]]
+  :dependencies [[org.clojure/clojure "1.12.1"]
+                 [com.github.oliyh/martian "0.1.32"]
+                 [com.github.oliyh/martian-httpkit "0.1.32"]
+                 [less-awful-ssl "1.0.7"]
+                 [http-kit/http-kit "2.9.0-beta1"]]
   :main ^:skip-aot kubernetes-api.core
   :resource-paths ["resources"]
   :target-path "target/%s"
@@ -19,5 +19,5 @@
             "lint-fix" ["do" ["cljfmt" "fix"] ["nsorg" "--replace"] ["kibit" "--replace"]]}
   :profiles {:uberjar {:aot :all}
              :dev {:resource-paths ["test/kubernetes_api/resources"]
-                   :dependencies [[nubank/matcher-combinators "3.8.5"]
+                   :dependencies [[nubank/matcher-combinators "3.9.1"]
                                   [nubank/mockfn "0.7.0"]]}})

--- a/src/kubernetes_api/interceptors/encoders.clj
+++ b/src/kubernetes_api/interceptors/encoders.clj
@@ -14,4 +14,4 @@
 
 
 (defn new []
-  (martian.interceptors/encode-body (default-encoders)))
+  (martian.interceptors/encode-request (default-encoders)))


### PR DESCRIPTION
Martian renamed encode-body to encode-request and did not provide a backwards-compatible def.  When including this lib in another project that uses a newer version of martian, things break.  So hence this PR, which also does other dependency updates.