### PR TITLE
fix: use kind from old versions

### DIFF
--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -113,7 +113,7 @@
                 :request {:namespace \"default\"
                           :body {:apiVersion \"v1\", ...}})"
   [k8s {:keys [request] :as params}]
-  (if-let [action (internals.client/find-preferred-route k8s (dissoc params :request))]
+  (if-let [action (internals.client/select-route k8s (dissoc params :request))]
     (internals.martian/response-for k8s action (or request {}))
     (throw (ex-info "Could not find action" {:search (dissoc params :request)}))))
 
@@ -148,12 +148,13 @@
     => [:Deployment
          [:create \"description\"]
          ...]"
-  ([{:keys [handlers] :as k8s}]
-   (->> (filter (partial internals.client/preffered-version? k8s) handlers)
-        (group-by internals.client/kind)
+  ([{:keys [handlers] :as _k8s}]
+   (->> (group-by internals.client/kind handlers)
         (map (fn [[kind handlers]]
                (vec (cons (keyword kind)
-                          (mapv (juxt internals.client/action :summary) handlers)))))
+                          (mapv (fn [[action handlers]]
+                                  (vector action (some :summary handlers)))
+                                (group-by internals.client/action handlers))))))
         (sort-by (comp str first))
         vec))
   ([k8s kind]
@@ -166,7 +167,7 @@
     mostly for debugging. For customizing this, use the :interceptors option
     while creating an client"
   [k8s {:keys [request] :as params}]
-  (if-let [action (internals.client/find-preferred-route k8s (dissoc params :request))]
+  (if-let [action (internals.client/select-route k8s (dissoc params :request))]
     (martian/request-for k8s action (or request {}))
     (throw (ex-info "Could not find action" {:search (dissoc params :request)}))))
 
@@ -174,4 +175,4 @@
   "Returns everything on a specific action, including request and response
     schemas"
   [k8s params]
-  (martian/explore k8s (internals.client/find-preferred-route k8s (dissoc params :request))))
+  (martian/explore k8s (internals.client/select-route k8s (dissoc params :request))))

--- a/src/kubernetes_api/internals/client.clj
+++ b/src/kubernetes_api/internals/client.clj
@@ -1,7 +1,8 @@
 (ns kubernetes-api.internals.client
   (:require [camel-snake-kebab.core :as csk]
             [clojure.string :as string]
-            [kubernetes-api.misc :as misc]))
+            [kubernetes-api.misc :as misc]
+            [kubernetes-api.internals.meta :as meta]))
 
 (defn pascal-case-routes [k8s]
   (update k8s :handlers
@@ -89,6 +90,15 @@
                       (= (boolean all-namespaces?) (all-namespaces-route? (:route-name handler))))))
        (map :route-name)))
 
+(defn find-handler [k8s {:keys [all-namespaces?] :as _search-params
+                       search-kind :kind
+                       search-action :action}]
+  (->> (:handlers k8s)
+       (filter (fn [handler]
+                 (and (or (= (keyword search-kind) (kind handler)) (nil? search-kind))
+                      (or (= (keyword search-action) (action handler)) (nil? search-action))
+                      (= (boolean all-namespaces?) (all-namespaces-route? (:route-name handler))))))))
+
 (defn version-of [k8s route-name]
   (->> (swagger-definition-for-route k8s route-name)
        :x-kubernetes-group-version-kind
@@ -129,8 +139,100 @@
        (filter (fn [x] (not (string/ends-with? (name x) "Status"))))
        ((partial choose-preffered-version k8s))))
 
+
 (defn preffered-version? [k8s handler]
   (let [preffered-route (find-preferred-route k8s {:kind   (handler-kind handler)
                                                    :action (handler-action handler)})]
     (and (= (handler-version handler) (version-of k8s preffered-route))
          (= (handler-group handler) (group-of k8s preffered-route)))))
+
+(defn k8s-version-pattern [s]
+  (when (seq s)
+    (when-let [groups (re-matches #"^v(\d+)(alpha|beta|)(\d*)$" s)]
+      {:raw s :ga (Integer/parseInt (nth groups 1)) :channel (nth groups 2) :postversion (when (seq (nth groups 3)) (Integer/parseInt (nth groups 3)))})))
+
+(defn compare-channel [a b] 
+  (let [channels {"alpha" 2 "beta" 1 "" 0}] 
+    (compare (get channels a 3) (get channels b 3))))
+
+(defn compare-k8s-versions [a b]
+  (let [k8s-a (k8s-version-pattern a)
+        k8s-b (k8s-version-pattern b)]
+    (cond 
+      (and (nil? k8s-a) (not (nil? k8s-b)))
+      1
+
+      (and (not (nil? k8s-a)) (nil? k8s-b))
+      -1
+
+      (and (nil? k8s-a) (nil? k8s-b))
+      (compare a b)
+
+      (not= (:channel k8s-a) (:channel k8s-b))
+      (compare-channel (:channel k8s-a) (:channel k8s-b))
+
+
+      (not= (:ga k8s-a) (:ga k8s-b))
+      (compare (:ga k8s-b) (:ga k8s-a))
+
+
+      :else (compare (:postversion k8s-a) (:postversion k8s-b)))))
+
+(defn compare-group [k8s a b]
+  (letfn [(preffered-version-of [group]
+                                (->> (all-versions k8s)
+                                     (some #(= (:name %) group))
+                                     :prefferedVersion
+                                     :version))]
+    (compare-k8s-versions (preffered-version-of a) (preffered-version-of b))))
+
+(defn compare-handler-version [k8s a b]
+  (cond
+    (not= (handler-group a) (handler-group b))
+    (compare-group k8s (handler-group a) (handler-group b))
+
+    (and (preffered-version? k8s a) (preffered-version? k8s b))
+    (compare-k8s-versions (handler-version a) (handler-version b))
+
+    (preffered-version? k8s a)
+    -1
+
+    (preffered-version? k8s b)
+    1
+
+    :else
+    (compare-k8s-versions (handler-version a) (handler-version b))))
+
+(defn kind-handlers [k8s kind]
+  (->> (:handlers k8s)
+       (filter (fn [handler] (= kind (kind handler))))
+       (sort compare-handler-version)))
+
+(defn kind-handler [k8s kind] 
+  (first (kind-handlers k8s kind)))
+
+
+(defn from-api-version? [api handler]
+  (let [{:keys [group version]} (meta/group-version api)] 
+    (and (= group (handler-group handler))
+         (= version (handler-version handler)))))
+
+(defn find-explicit-api-route [k8s api search-params]
+  (->> (find-route k8s search-params)
+       (filter (partial from-api-version? api))
+       first))
+
+(defn find-version-priority-handler [k8s search-params] 
+  (->> (find-handler k8s search-params)
+       (filter (fn [x] (not (string/ends-with? (name (:route-name x)) "Status"))))
+       (sort (partial compare-handler-version k8s))
+       first))
+
+(defn find-version-priority-route [k8s search-params]
+  (:route-name (find-version-priority-handler k8s search-params)))
+
+(defn select-route [k8s search-params]
+  (if-let [api (or (:api search-params)
+                   (get-in search-params [:request :apiVersion]))]
+    (find-explicit-api-route k8s api search-params)
+    (find-version-priority-route k8s search-params)))

--- a/src/kubernetes_api/internals/meta.clj
+++ b/src/kubernetes_api/internals/meta.clj
@@ -1,0 +1,19 @@
+(ns kubernetes-api.internals.meta)
+
+(defn group-version
+  "Receives a apiVersion and returns a map with group and version
+ 
+   Example
+   (group-version \"apps/v1\") => {:group \"apps\" :version \"v1\"}
+   (group-version :apps/v1) => {:group \"apps\" :version \"v1\"}
+   (group-version :core/v1) => {:group \"\" :version \"v1\"}
+   (group-version :v1) => {:group \"\" :version \"v1\"}
+   "
+  [api]
+  (letfn [(group [s] (if (= s "core") "" s))]
+    (cond
+      (nil? api) nil
+      (string? api) (group-version (keyword api))
+      (and (keyword? api) (seq (namespace api))) {:group (group (namespace api))
+                                                  :version (name api)}
+      (keyword? api) {:group (group (name api))})))

--- a/test/kubernetes_api/core_test.clj
+++ b/test/kubernetes_api/core_test.clj
@@ -1,5 +1,100 @@
 (ns kubernetes-api.core-test
   (:require [clojure.test :refer :all]
-            [kubernetes-api.core :as k8s-api]))
+            [matcher-combinators.test :refer [match?]]
+            [kubernetes-api.core :as k8s]))
 
 ;; TODO
+
+(deftest explore-test
+  (testing "example k8s"
+    (let [k8s-client {::k8s/core-api-versions {:versions ["v1"]}
+                      ::k8s/api-group-list {:groups [{:name "fruits.group.dev"
+                                                      :versions [{:groupVersion "fruits.group.dev/v1alpha2" :version "v1alpha2"}]
+                                                      :preferredVersion {:groupVersion "fruits.group.dev/v1alpha2" :version "v1alpha2"}}
+                                                     {:name "vegetables.group.dev"
+                                                      :versions [{:groupVersion "vegetables.group.dev/v1alpha1" :version "v1alpha1"}]
+                                                      :preferredVersion {:groupVersion "vegetables.group.dev/v1alpha1" :version "v1alpha1"}}]}
+                      :handlers [{:route-name         :CreateV1alpha2Orange
+                                  :summary "create an Orange"
+                                  :swagger-definition {:x-kubernetes-action             "create"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1alpha2"
+                                                                                         :kind    "Orange"}}}
+                                 {:route-name         :UpdateV1alpha1Orange
+                                  :summary "replace the specified Orange"
+                                  :swagger-definition {:x-kubernetes-action             "update"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1alpha2"
+                                                                                         :kind    "Orange"}}}
+                                 {:route-name :CreateV1alpha1Carrot
+                                  :summary "create a Carrot"
+                                  :swagger-definition {:x-kubernetes-action             "create"
+                                                       :x-kubernetes-group-version-kind {:group   "vegetables.group.dev"
+                                                                                         :version "v1alpha1"
+                                                                                         :kind    "Carrot"}}}
+                                 {:route-name :UpdateV1alpha1Carrot
+                                  :summary "replace the specified Carrot"
+                                  :swagger-definition {:x-kubernetes-action             "update"
+                                                       :x-kubernetes-group-version-kind {:group   "vegetables.group.dev"
+                                                                                         :version "v1alpha1"
+                                                                                         :kind    "Carrot"}}}]}]
+      (is (match? (k8s/explore k8s-client)
+                  [[:Carrot
+                    [:create "create a Carrot"]
+                    [:update "replace the specified Carrot"]]
+                   [:Orange
+                    [:create "create an Orange"]
+                    [:update "replace the specified Orange"]]]))
+      (is (match? (k8s/explore k8s-client :Carrot)
+                  [:Carrot
+                   [:create "create a Carrot"]
+                   [:update "replace the specified Carrot"]]))
+      (is (match? (k8s/explore k8s-client :Orange)
+                  [:Orange
+                   [:create "create an Orange"]
+                   [:update "replace the specified Orange"]]))))
+  (testing "kind not in preffered version"
+    (let [k8s-client {::k8s/core-api-versions {:versions ["v1"]}
+                      ::k8s/api-group-list {:groups [{:name "fruits.group.dev"
+                                                      :versions [{:groupVersion "fruits.group.dev/v1alpha2" :version "v1beta1"}
+                                                                 {:groupVersion "fruits.group.dev/v1alpha1" :version "v1alpha1"}]
+                                                      :preferredVersion {:groupVersion "fruits.group.dev/v1beta1" :version "v1alpha1"}}]}
+                      :handlers [{:route-name         :CreateV1beta1Orange
+                                  :summary "create an Orange"
+                                  :swagger-definition {:x-kubernetes-action             "create"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1beta1"
+                                                                                         :kind    "Orange"}}}
+                                 {:route-name         :UpdateV1beta1Orange
+                                  :summary "replace the specified Orange"
+                                  :swagger-definition {:x-kubernetes-action             "update"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1beta1"
+                                                                                         :kind    "Orange"}}}
+                                 {:route-name :CreateV1alpha1Apple
+                                  :summary "create an Apple"
+                                  :swagger-definition {:x-kubernetes-action             "create"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1alpha1"
+                                                                                         :kind    "Apple"}}}
+                                 {:route-name :UpdateV1alpha1Apple
+                                  :summary "replace the specified Apple"
+                                  :swagger-definition {:x-kubernetes-action             "update"
+                                                       :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                                         :version "v1alpha1"
+                                                                                         :kind    "Apple"}}}]}]
+      (is (match? (k8s/explore k8s-client)
+                  [[:Apple
+                    [:create "create an Apple"]
+                    [:update "replace the specified Apple"]]
+                   [:Orange
+                    [:create "create an Orange"]
+                    [:update "replace the specified Orange"]]]))
+      (is (match? (k8s/explore k8s-client :Apple)
+                  [:Apple
+                   [:create "create an Apple"]
+                   [:update "replace the specified Apple"]]))
+      (is (match? (k8s/explore k8s-client :Orange)
+                  [:Orange
+                   [:create "create an Orange"]
+                   [:update "replace the specified Orange"]])))))

--- a/test/kubernetes_api/internals/client_test.clj
+++ b/test/kubernetes_api/internals/client_test.clj
@@ -223,3 +223,80 @@
                                                                         :x-kubernetes-group-version-kind {:group   "fruits"
                                                                                                           :version "v1alpha1"
                                                                                                           :kind    "Orange"}}})))))
+
+
+(deftest compare-handler-version-test
+  (let [k8s-client {:kubernetes-api.core/core-api-versions {:versions []} 
+                    :kubernetes-api.core/api-group-list {:groups [{:name "fruits.group.dev"
+                                                                   :versions [{:groupVersion "fruits.group.dev/v2" :version "v2"}
+                                                                              {:groupVersion "fruits.group.dev/v2beta1"  :version "v2beta1"}
+                                                                              {:groupVersion "fruits.group.dev/v1" :version "v1"}
+                                                                              {:groupVersion "fruits.group.dev/v1alpha2" :version "v1beta1"}
+                                                                              {:groupVersion "fruits.group.dev/v1alpha1" :version "v1alpha1"}]
+                                                                   :preferredVersion {:groupVersion "fruits.group.dev/v1" :version "v1"}}]}}]
+    
+    (testing "when both are preffered version within same group, consider it equal"
+      (let [a {:route-name         :CreateV1Orange
+               :swagger-definition {:x-kubernetes-action             "create"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v1"
+                                                                      :kind    "Orange"}}}
+            b {:route-name         :UpdateV1Orange
+               :swagger-definition {:x-kubernetes-action             "update"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v1"
+                                                                      :kind    "Orange"}}}]
+        (is (zero? (internals.client/compare-handler-version (assoc k8s-client :handlers [a b]) a b)))))
+    
+(testing "when both are not preffered version within same group, consider it based on version priority -- GA should come first"
+      (let [a {:route-name         :CreateV1Orange
+               :swagger-definition {:x-kubernetes-action             "create"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v2"
+                                                                      :kind    "Orange"}}}
+            b {:route-name         :UpdateV1Orange
+               :swagger-definition {:x-kubernetes-action             "update"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v2beta1"
+                                                                      :kind    "Orange"}}}]
+        (is (< (internals.client/compare-handler-version (assoc k8s-client :handlers [a b]) a b) 0))))
+
+(testing "when both are not preffered version within same group, consider it based on version priority -- beta should come first than alpha"
+      (let [a {:route-name         :CreateV1Orange
+               :swagger-definition {:x-kubernetes-action             "create"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v1beta1"
+                                                                      :kind    "Orange"}}}
+            b {:route-name         :UpdateV1Orange
+               :swagger-definition {:x-kubernetes-action             "update"
+                                    :x-kubernetes-group-version-kind {:group   "fruits.group.dev"
+                                                                      :version "v1alpha1"
+                                                                      :kind    "Orange"}}}]
+        (is (< (internals.client/compare-handler-version (assoc k8s-client :handlers [a b]) a b) 0))))
+    ))
+    
+
+(deftest compare-k8s-versions-test
+  (testing "sorting"
+    (is (match?
+         ["v2"
+          "v1"
+          "v3beta1"
+          "v2beta1"
+          "v1beta1"
+          "v4alpha1"
+          "v1alpha1"
+          "foo1" 
+          "foo10"]
+         (sort internals.client/compare-k8s-versions 
+               ["v1alpha1" 
+                "v1beta1"
+                "v1" 
+                "v2beta1" 
+                "v3beta1" 
+                "v4alpha1"
+                "v2" 
+                "foo1" 
+                "foo10"])))))
+
+


### PR DESCRIPTION
## Context

When using a kind that is not available in the prefferedVersion of the API Group, it fails to find the route and it doesn't work

## What
The fix is to always find the Group Version for each kind, this way if a kind is only available in previous versions it still works