### PR TITLE
feat: add loader for KUBECONFIG support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ You can also define client certificates
                                          :client-key  "/some/path/client-java.key"}))
 ```
 
+### kubeconfig loader
+You can load configuration from a kubeconfig file, either by explicit setting it, or by setting the environment variable KUBECONFIG.
+It also supports multiple files
+
+```clojure
+(def k8s (->> (loader.kubeconfig/load-context
+                {:kubeconfig "/path/to/some/kubeconfig.yaml"
+                 :context "prod-xpto-000-context"})
+              (k8s/from-context)))
+
+; load from KUBECONFIG or defaulting to ~/.kube/config
+(def k8s (->> (loader.kubeconfig/load-context
+                {:context "prod-xpto-000-context"})
+              (k8s/from-context)))
+
+; load multiple files. It will find the first context that matches.
+(def k8s (->> (loader.kubeconfig/load-context
+                {:kubeconfig ["/path/to/some/kubeconfig.yaml"
+                              "/path/to/another/kubeconfig.yaml"]
+                 :context "prod-xpto-000-context"})
+              (k8s/from-context)))
+```
+
+
 #### OpenAPI config
 
 ##### Discovery

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
             [lein-kibit "0.1.6"]
             [lein-nsorg "0.2.0"]]
   :cljfmt {:indents {providing [[:inner 0]]}}
-  :dependencies [[org.clojure/clojure "1.11.0"]
+  :dependencies [[org.clojure/clojure "1.11.0"] 
+                 [clj-commons/clj-yaml "1.0.29"]
                  [com.github.oliyh/martian "0.1.26"]
                  [com.github.oliyh/martian-httpkit "0.1.26"]
                  [less-awful-ssl "1.0.6"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "1.2.0-rc.0"
+(defproject nubank/k8s-api "1.2.0"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "1.2.0-SNAPSHOT"
+(defproject nubank/k8s-api "1.2.0-rc.0"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [com.github.oliyh/martian "0.1.26"]
                  [com.github.oliyh/martian-httpkit "0.1.26"]
                  [less-awful-ssl "1.0.6"]
+                 [org.bouncycastle/bcpkix-jdk18on "1.79"]
                  [http-kit/http-kit "2.8.0-alpha3"]]
   :main ^:skip-aot kubernetes-api.core
   :resource-paths ["resources"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/k8s-api "1.2.0"
+(defproject nubank/k8s-api "1.3.0-SNAPSHOT"
   :description "A library to talk with kubernetes api"
   :url "https://github.com/nubank/k8s-api"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/kubernetes_api/core.clj
+++ b/src/kubernetes_api/core.clj
@@ -1,6 +1,7 @@
 (ns kubernetes-api.core
   (:require [kubernetes-api.extensions.custom-resource-definition :as crd]
             [kubernetes-api.interceptors.auth :as interceptors.auth]
+            [kubernetes-api.interceptors.auth.kubeconfig :as auth.kubeconfig]
             [kubernetes-api.interceptors.encoders :as interceptors.encoders]
             [kubernetes-api.interceptors.raise :as interceptors.raise]
             [kubernetes-api.internals.client :as internals.client]
@@ -98,6 +99,18 @@
     (assoc k8s
            ::api-group-list (internals.martian/response-for k8s :GetApiVersions)
            ::core-api-versions (internals.martian/response-for k8s :GetCoreApiVersions))))
+
+
+(defn from-context 
+  "Creates a client from a context info
+
+   context-info is a map with the following keys:
+     :context - has info about the :cluster and :user names, and potentially :namespace
+     :cluster - has :server, and potentially certificate authority
+     :user -    has authentication strategy"
+  [context-info]
+  (client (:server (:cluster context-info))
+          (auth.kubeconfig/auth-options context-info)))
 
 (defn invoke
   "Invoke a action on kubernetes api

--- a/src/kubernetes_api/interceptors/auth.clj
+++ b/src/kubernetes_api/interceptors/auth.clj
@@ -1,44 +1,23 @@
 (ns kubernetes-api.interceptors.auth
   (:require [kubernetes-api.interceptors.auth.ssl :as auth.ssl]
+            [kubernetes-api.interceptors.auth.options :as auth.options]
             [tripod.log :as log]))
-
-(defn- ca-cert? [{:keys [ca-cert certificate-authority-data]}]
-  (or (some? ca-cert)
-      (some? certificate-authority-data)))
-
-(defn- client-cert? [{:keys [client-cert client-certificate-data]}]
-  (or (some? client-cert)
-      (some? client-certificate-data)))
-
-(defn- client-key? [{:keys [client-key client-key-data]}]
-  (or (some? client-key)
-      (some? client-key-data)))
-
-(defn- client-certs? [opts]
-  (and (ca-cert? opts) (client-cert? opts) (client-key? opts)))
-
-(defn- basic-auth? [{:keys [username password]}]
-  (every? some? [username password]))
 
 (defn- basic-auth [{:keys [username password]}]
   (str username ":" password))
 
-(defn- token? [{:keys [token]}]
-  (some? token))
-
-(defn- token-fn? [{:keys [token-fn]}]
-  (some? token-fn))
-
-(defn request-auth-params [{:keys [token-fn insecure?] :as opts}]
+(defn request-auth-params [{:keys [token-fn auth-fn insecure?] :as opts}]
   (merge
-    {:insecure? (or insecure? false)}
-   (when (and (ca-cert? opts) (not (client-certs? opts)))
+   {:insecure? (or insecure? false)}
+   (when (and (auth.options/ca-cert? opts) (not (auth.options/mtls-certs? opts)))
      {:sslengine (auth.ssl/ca-cert->ssl-engine opts)})
    (cond
-     (basic-auth? opts) {:basic-auth (basic-auth opts)}
-     (token? opts) {:oauth-token (:token opts)}
-     (token-fn? opts) {:oauth-token (token-fn opts)}
-     (client-certs? opts) {:sslengine (auth.ssl/client-certs->ssl-engine opts)}
+     (auth.options/basic-auth? opts) {:basic-auth (basic-auth opts)}
+     (auth.options/token? opts) {:oauth-token (:token opts)}
+     (auth.options/token-fn? opts) {:oauth-token (token-fn opts)}
+     (auth.options/mtls-certs? opts) {:sslengine (auth.ssl/client-certs->ssl-engine opts)}
+     (auth.options/auth-fn? opts) (let [auth-opts (auth-fn)]
+                                    (request-auth-params (dissoc auth-opts :auth-fn)))
      :else (do (log/info "No authentication method found")
                {}))))
 

--- a/src/kubernetes_api/interceptors/auth/kubeconfig.clj
+++ b/src/kubernetes_api/interceptors/auth/kubeconfig.clj
@@ -2,9 +2,12 @@
   (:require
     [cheshire.core :as json]
     [kubernetes-api.interceptors.auth.options :as auth.options]
+    [kubernetes-api.loader.kubeconfig :as loader.kubeconfig]
     [clojure.java.shell :as sh]
     [tripod.log :as log]
-    [clojure.string :as string]))
+    [clojure.java.io :as io]
+    [clojure.string :as string])
+  (:import (java.nio.file Paths)))
 
 (defn env-var-map
   [env]
@@ -78,21 +81,30 @@
   "Returns a map of authentication options based on the context info.
    This options should be used to instantiate a kubernetes-api.core/client."
   [{:keys [user cluster] :as context-info}]
-  (cond 
-    (and (auth.options/client-cert-key-pair? user)
-         (auth.options/ca-cert? cluster)) 
-    (select-keys (merge user cluster) [:client-cert :client-certificate-data :client-key :client-key-data :ca-cert :certificate-authority-data])
+  (merge
+   (when (and (auth.options/ca-cert? cluster)
+              (not (auth.options/client-cert-key-pair? user)))
+     (update (select-keys cluster [:certificate-authority :certificate-authority-data])
+             :certificate-authority (fn [ca-cert] 
+                                      (when (some? ca-cert)
+                                        (if (.isAbsolute (io/file ca-cert))
+                                          ca-cert
+                                          (.getAbsolutePath (io/file (.getParent (::loader.kubeconfig/kubeconfig-file context-info)) ca-cert)))))))
+   (cond 
+     (and (auth.options/client-cert-key-pair? user)
+          (auth.options/ca-cert? cluster))
+     (select-keys (merge user cluster) [:client-cert :client-certificate-data :client-key :client-key-data :ca-cert :certificate-authority :certificate-authority-data])
 
-    (auth.options/token? user)
-    (select-keys user [:token])
+     (auth.options/token? user)
+     (select-keys user [:token])
 
-    (auth.options/token-file? {:token-file (:tokenFile user)})
-    {:token-fn (fn [] (string/trim-newline (slurp (:tokenFile user))))}
+     (auth.options/token-file? {:token-file (:tokenFile user)})
+     {:token-fn (fn [] (string/trim-newline (slurp (:tokenFile user))))}
 
-    (auth.options/basic-auth? user)
-    (select-keys user [:username :password])
+     (auth.options/basic-auth? user)
+     (select-keys user [:username :password])
 
-    (auth.options/exec? user)
-    {:auth-fn (credentials-fn (new-exec-runner context-info))}
+     (auth.options/exec? user)
+     {:auth-fn (credentials-fn (new-exec-runner context-info))}
 
-    :else {}))
+     :else {})))

--- a/src/kubernetes_api/interceptors/auth/kubeconfig.clj
+++ b/src/kubernetes_api/interceptors/auth/kubeconfig.clj
@@ -1,0 +1,98 @@
+(ns kubernetes-api.interceptors.auth.kubeconfig
+  (:require
+    [cheshire.core :as json]
+    [kubernetes-api.interceptors.auth.options :as auth.options]
+    [clojure.java.shell :as sh]
+    [tripod.log :as log]
+    [clojure.string :as string]))
+
+(defn env-var-map
+  [env]
+  (into {} (map (juxt :name :value) env)))
+
+(defn parse-output [{:keys [out exit err] :as output}]
+  (if (zero? exit)
+    {:exec-credential (json/parse-string out true) :err err}
+    output))
+
+(defn new-exec-credential [{:keys [apiVersion provideClusterInfo] :as _user-exec} cluster]
+  {:apiVersion (or apiVersion "client.authentication.k8s.io/v1")
+   :kind "ExecCredential"
+   :spec (merge (when provideClusterInfo {:cluster cluster})
+                {:interactive false})})
+
+(defn exec-fn [{:keys [user cluster] :as _context-info}]
+  (let [{:keys [command args env] :as user-exec} (:exec user)]
+    (fn [& _]
+      (log/info :msg "executing exec command" :command command :args args :env env)
+      (parse-output (apply sh/sh (cons command (concat args [:env (merge (env-var-map env)
+                                                                         {"KUBERNETES_EXEC_INFO" (json/generate-string (new-exec-credential user-exec cluster))})])))))))
+
+
+
+
+(defprotocol CredentialGetter
+  (get-credential [this]))
+
+(defn expired? [{:keys [status] :as _exec-credential}]
+  (if-let [expiration-timestamp (:expirationTimestamp status)]
+    (.isAfter (java.time.Instant/now)
+              (java.time.Instant/parse expiration-timestamp))
+    true))
+
+(defn string->base64 [s]
+  (.encodeToString (java.util.Base64/getMimeEncoder) 
+                   (.getBytes s java.nio.charset.StandardCharsets/UTF_8)))
+
+(defn exec-credential->auth-options [{:keys [status] :as _exec-credential} cluster]
+  (cond (some? (:token status))
+        {:token (:token status)}
+
+        (and (some? (:clientCertificateData status))
+             (some? (:clientKeyData status))
+             (some? (:certificate-authority-data cluster)))
+        {:client-certificate-data (string->base64 (:clientCertificateData status))
+         :client-key-data (string->base64 (:clientKeyData status))
+         :certificate-authority-data (:certificate-authority-data cluster)}))
+
+(defn credentials-fn [exec-runner]
+  (fn [& _] (get-credential exec-runner)))
+
+(defrecord ExecCredentialRunner [exec-credential exec-fn cluster]
+  CredentialGetter
+  (get-credential [_]
+    (let [exec-credential* @exec-credential]
+      (exec-credential->auth-options
+       (if (and (not (expired? exec-credential*))
+                (some? exec-credential*))
+         exec-credential*
+         (swap! exec-credential (fn [_] (:exec-credential (exec-fn)))))
+       cluster))))
+
+(defn new-exec-runner [{:keys [cluster] :as context-info}]
+  (map->ExecCredentialRunner {:exec-credential (atom nil)
+                              :exec-fn (exec-fn context-info)
+                              :cluster cluster}))
+
+(defn auth-options 
+  "Returns a map of authentication options based on the context info.
+   This options should be used to instantiate a kubernetes-api.core/client."
+  [{:keys [user cluster] :as context-info}]
+  (cond 
+    (and (auth.options/client-cert-key-pair? user)
+         (auth.options/ca-cert? cluster)) 
+    (select-keys (merge user cluster) [:client-cert :client-certificate-data :client-key :client-key-data :ca-cert :certificate-authority-data])
+
+    (auth.options/token? user)
+    (select-keys user [:token])
+
+    (auth.options/token-file? {:token-file (:tokenFile user)})
+    {:token-fn (fn [] (string/trim-newline (slurp (:tokenFile user))))}
+
+    (auth.options/basic-auth? user)
+    (select-keys user [:username :password])
+
+    (auth.options/exec? user)
+    {:auth-fn (credentials-fn (new-exec-runner context-info))}
+
+    :else {}))

--- a/src/kubernetes_api/interceptors/auth/options.clj
+++ b/src/kubernetes_api/interceptors/auth/options.clj
@@ -1,0 +1,37 @@
+(ns kubernetes-api.interceptors.auth.options)
+
+(defn ca-cert? [{:keys [ca-cert certificate-authority-data]}]
+  (or (some? ca-cert)
+      (some? certificate-authority-data)))
+
+(defn client-cert? [{:keys [client-cert client-certificate-data]}]
+  (or (some? client-cert)
+      (some? client-certificate-data)))
+
+(defn client-key? [{:keys [client-key client-key-data]}]
+  (or (some? client-key)
+      (some? client-key-data)))
+
+(defn client-cert-key-pair? [opts]
+  (and (client-cert? opts) (client-key? opts)))
+
+(defn mtls-certs? [opts]
+  (and (ca-cert? opts) (client-cert? opts) (client-key? opts)))
+
+(defn basic-auth? [{:keys [username password]}]
+  (every? some? [username password]))
+
+(defn token? [{:keys [token]}]
+  (some? token))
+
+(defn token-fn? [{:keys [token-fn]}]
+  (some? token-fn))
+
+(defn token-file? [{:keys [token-file]}]
+  (some? token-file))
+
+(defn exec? [{:keys [exec]}]
+  (some? exec))
+
+(defn auth-fn? [{:keys [auth-fn]}]
+  (some? auth-fn))

--- a/src/kubernetes_api/interceptors/auth/options.clj
+++ b/src/kubernetes_api/interceptors/auth/options.clj
@@ -1,7 +1,8 @@
 (ns kubernetes-api.interceptors.auth.options)
 
-(defn ca-cert? [{:keys [ca-cert certificate-authority-data]}]
+(defn ca-cert? [{:keys [ca-cert certificate-authority certificate-authority-data]}]
   (or (some? ca-cert)
+      (some? certificate-authority)
       (some? certificate-authority-data)))
 
 (defn client-cert? [{:keys [client-cert client-certificate-data]}]

--- a/src/kubernetes_api/interceptors/auth/ssl.clj
+++ b/src/kubernetes_api/interceptors/auth/ssl.clj
@@ -1,6 +1,8 @@
 (ns kubernetes-api.interceptors.auth.ssl
-  (:require [less.awful.ssl :as ssl])
+  (:require [clojure.string :as str]
+            [less.awful.ssl :as ssl])
   (:import (java.io ByteArrayInputStream)
+           (java.nio.charset StandardCharsets)
            (java.security KeyStore)
            (java.security.spec PKCS8EncodedKeySpec)
            (java.security.cert Certificate)
@@ -19,14 +21,40 @@
     (.load nil nil)
     (.setCertificateEntry "cacert" (load-certificate cert))))
 
+(defn- der-length ^bytes [n]
+  (if (< n 0x80)
+    (byte-array [n])
+    (let [octets (loop [n n acc []]
+                   (if (zero? n)
+                     acc
+                     (recur (unsigned-bit-shift-right n 8) (cons (bit-and n 0xff) acc))))]
+      (byte-array (cons (bit-or 0x80 (count octets)) octets)))))
+
+(defn- der-tlv ^bytes [tag ^bytes value]
+  (byte-array (concat [(int tag)] (der-length (alength value)) value)))
+
+(defn- pkcs1->pkcs8 ^bytes [^bytes pkcs1-der]
+  ;; Wrap a PKCS#1 RSA key in a PKCS#8 AlgorithmIdentifier envelope so that
+  ;; PKCS8EncodedKeySpec can parse it.
+  ;; RSA OID: 1.2.840.113549.1.1.1
+  (let [rsa-oid  (byte-array [0x06 0x09 0x2a 0x86 0x48 0x86 0xf7 0x0d 0x01 0x01 0x01])
+        null-val (byte-array [0x05 0x00])
+        alg-id   (der-tlv 0x30 (byte-array (concat rsa-oid null-val)))
+        version  (byte-array [0x02 0x01 0x00])
+        key-os   (der-tlv 0x04 pkcs1-der)]
+    (der-tlv 0x30 (byte-array (concat version alg-id key-os)))))
+
 (defn base64->private-key
   [base64-private-key]
-(->> (String. (ssl/base64->binary base64-private-key) java.nio.charset.StandardCharsets/UTF_8)
-    (re-find #"(?ms)^-----BEGIN ?.*? PRIVATE KEY-----$(.+)^-----END ?.*? PRIVATE KEY-----$")
-    last
-    ssl/base64->binary
-    PKCS8EncodedKeySpec.
-    (.generatePrivate ssl/rsa-key-factory)))
+  (let [pem-str   (String. (ssl/base64->binary base64-private-key) StandardCharsets/UTF_8)
+        pkcs1?    (str/includes? pem-str "BEGIN RSA PRIVATE KEY")
+        der-bytes (->> pem-str
+                       (re-find #"(?ms)^-----BEGIN ?.*? PRIVATE KEY-----$(.+)^-----END ?.*? PRIVATE KEY-----$")
+                       last
+                       ssl/base64->binary)]
+    (->> (if pkcs1? (pkcs1->pkcs8 der-bytes) der-bytes)
+         PKCS8EncodedKeySpec.
+         (.generatePrivate ssl/rsa-key-factory))))
 
 (defn private-key [{:keys [key key-data]}]
   (cond

--- a/src/kubernetes_api/interceptors/auth/ssl.clj
+++ b/src/kubernetes_api/interceptors/auth/ssl.clj
@@ -1,14 +1,14 @@
 (ns kubernetes-api.interceptors.auth.ssl
-  (:require [clojure.string :as str]
-            [less.awful.ssl :as ssl])
-  (:import (java.io ByteArrayInputStream)
+  (:require [less.awful.ssl :as ssl])
+  (:import (java.io ByteArrayInputStream StringReader)
            (java.nio.charset StandardCharsets)
            (java.security KeyStore)
-           (java.security.spec PKCS8EncodedKeySpec)
            (java.security.cert Certificate)
-           (javax.net.ssl SSLContext
-                          TrustManager
-                          KeyManager)))
+           (javax.net.ssl SSLContext TrustManager KeyManager)
+           (org.bouncycastle.asn1.pkcs PrivateKeyInfo)
+           (org.bouncycastle.openssl PEMKeyPair PEMParser)
+           (org.bouncycastle.jce.provider BouncyCastleProvider)
+           (org.bouncycastle.openssl.jcajce JcaPEMKeyConverter)))
 
 (defn load-certificate ^Certificate [{:keys [cert-file cert-data]}]
   (cond
@@ -21,44 +21,21 @@
     (.load nil nil)
     (.setCertificateEntry "cacert" (load-certificate cert))))
 
-(defn- der-length ^bytes [n]
-  (if (< n 0x80)
-    (byte-array [n])
-    (let [octets (loop [n n acc []]
-                   (if (zero? n)
-                     acc
-                     (recur (unsigned-bit-shift-right n 8) (cons (bit-and n 0xff) acc))))]
-      (byte-array (cons (bit-or 0x80 (count octets)) octets)))))
+(defn- pem-str->private-key [^String pem-str]
+  (with-open [reader (StringReader. pem-str)]
+    (let [obj  (.readObject (PEMParser. reader))
+          conv (-> (JcaPEMKeyConverter.) (.setProvider (BouncyCastleProvider.)))]
+      (if (instance? PEMKeyPair obj)
+        (-> (.getKeyPair conv ^PEMKeyPair obj) .getPrivate)
+        (.getPrivateKey conv ^PrivateKeyInfo obj)))))
 
-(defn- der-tlv ^bytes [tag ^bytes value]
-  (byte-array (concat [(int tag)] (der-length (alength value)) value)))
-
-(defn- pkcs1->pkcs8 ^bytes [^bytes pkcs1-der]
-  ;; Wrap a PKCS#1 RSA key in a PKCS#8 AlgorithmIdentifier envelope so that
-  ;; PKCS8EncodedKeySpec can parse it.
-  ;; RSA OID: 1.2.840.113549.1.1.1
-  (let [rsa-oid  (byte-array [0x06 0x09 0x2a 0x86 0x48 0x86 0xf7 0x0d 0x01 0x01 0x01])
-        null-val (byte-array [0x05 0x00])
-        alg-id   (der-tlv 0x30 (byte-array (concat rsa-oid null-val)))
-        version  (byte-array [0x02 0x01 0x00])
-        key-os   (der-tlv 0x04 pkcs1-der)]
-    (der-tlv 0x30 (byte-array (concat version alg-id key-os)))))
-
-(defn base64->private-key
-  [base64-private-key]
-  (let [pem-str   (String. (ssl/base64->binary base64-private-key) StandardCharsets/UTF_8)
-        pkcs1?    (str/includes? pem-str "BEGIN RSA PRIVATE KEY")
-        der-bytes (->> pem-str
-                       (re-find #"(?ms)^-----BEGIN ?.*? PRIVATE KEY-----$(.+)^-----END ?.*? PRIVATE KEY-----$")
-                       last
-                       ssl/base64->binary)]
-    (->> (if pkcs1? (pkcs1->pkcs8 der-bytes) der-bytes)
-         PKCS8EncodedKeySpec.
-         (.generatePrivate ssl/rsa-key-factory))))
+(defn base64->private-key [base64-private-key]
+  (-> (String. (ssl/base64->binary base64-private-key) StandardCharsets/UTF_8)
+      pem-str->private-key))
 
 (defn private-key [{:keys [key key-data]}]
   (cond
-    (some? key)      (ssl/private-key key)
+    (some? key)      (-> (slurp key) pem-str->private-key)
     (some? key-data) (base64->private-key key-data)))
 
 (defn ^"[Ljava.security.cert.Certificate;" load-certificate-chain
@@ -88,12 +65,12 @@
               nil))))
 
 (defn client-certs->ssl-engine
-  [{:keys [ca-cert certificate-authority-data client-cert client-certificate-data client-key client-key-data]}]
+  [{:keys [ca-cert certificate-authority certificate-authority-data client-cert client-certificate-data client-key client-key-data]}]
   (let [key {:key client-key
              :key-data client-key-data}
         cert {:cert-file client-cert
               :cert-data client-certificate-data}
-        ca-crt {:cert-file ca-cert
+        ca-crt {:cert-file (or ca-cert certificate-authority)
                 :cert-data certificate-authority-data}]
     (ssl/ssl-context->engine
      (client-certs->ssl-context key cert ca-crt))))
@@ -103,7 +80,7 @@
        (.init nil (into-array TrustManager [(less.awful.ssl/trust-manager (trust-store cert))]) nil)))
 
 (defn ca-cert->ssl-engine
-  [{:keys [ca-cert certificate-authority-data]}]
+  [{:keys [ca-cert certificate-authority certificate-authority-data]}]
   (ssl/ssl-context->engine
-   (ca-cert->ssl-context {:cert-file ca-cert
+   (ca-cert->ssl-context {:cert-file (or ca-cert certificate-authority)
                           :cert-data certificate-authority-data})))

--- a/src/kubernetes_api/loader/kubeconfig.clj
+++ b/src/kubernetes_api/loader/kubeconfig.clj
@@ -1,0 +1,53 @@
+(ns kubernetes-api.loader.kubeconfig
+  (:require [kubernetes-api.misc :as misc]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clj-yaml.core :as yaml]))
+
+
+(defn cluster-info [kubeconfig cluster-name]
+  (when-let [cluster (misc/find-first #(= (:name %) cluster-name) (:clusters kubeconfig))]
+    (:cluster cluster)))
+
+(defn user-info [kubeconfig user-name]
+  (when-let [user (misc/find-first #(= (:name %) user-name) (:users kubeconfig))]
+    (:user user)))
+
+(defn context-info [kubeconfig context-name]
+  (let [{:keys [cluster user] :as context} (:context (misc/find-first #(= (:name %) context-name) (:contexts kubeconfig)))
+        cluster-info (cluster-info kubeconfig cluster)
+        user-info (user-info kubeconfig user)]
+    (when (and (some? context) (some? cluster-info) (some? user-info))
+      {:cluster cluster-info
+       :user user-info
+       :context context})))
+
+(defn kubeconfig-files [kubeconfig]
+  (let [kubeconfig-input (or kubeconfig
+                             (System/getenv "KUBECONFIG")
+                             (io/file (System/getProperty "user.home") ".kube" "config"))]
+    (cond
+      (string? kubeconfig-input) (map io/file (string/split kubeconfig-input #":"))
+      (sequential? kubeconfig-input) (map io/file kubeconfig-input)
+      (instance? java.io.File kubeconfig-input) [kubeconfig-input])))
+
+(defn- kubeconfig-data [kubeconfig]
+  (->> (kubeconfig-files kubeconfig)
+       (mapv (fn [kubeconfig-file] (yaml/parse-string (slurp kubeconfig-file))))))
+
+
+(defn context
+  "Load a context from kubeconfig file(s) and context name.
+
+   [Options]
+   :kubeconfig - optional kubeconfig file(s), default to KUBECONFIG env var or
+                 ~/.kube/config.  It can be a string or a list of strings.
+   :context - optional context name, defaults to :current-context or \"default\"
+   "
+  [{:keys [kubeconfig context] :as _options}]
+  (->> (kubeconfig-data kubeconfig)
+       (keep (fn [kubeconfig-data]
+                     (context-info kubeconfig-data (or context
+                                                  (:default-context kubeconfig-data)
+                                                  "default"))))
+       first))

--- a/src/kubernetes_api/loader/kubeconfig.clj
+++ b/src/kubernetes_api/loader/kubeconfig.clj
@@ -20,7 +20,8 @@
     (when (and (some? context) (some? cluster-info) (some? user-info))
       {:cluster cluster-info
        :user user-info
-       :context context})))
+       :context context
+       ::kubeconfig-file (::kubeconfig-file kubeconfig)})))
 
 (defn kubeconfig-files [kubeconfig]
   (let [kubeconfig-input (or kubeconfig
@@ -33,7 +34,8 @@
 
 (defn- kubeconfig-data [kubeconfig]
   (->> (kubeconfig-files kubeconfig)
-       (mapv (fn [kubeconfig-file] (yaml/parse-string (slurp kubeconfig-file))))))
+       (mapv (fn [kubeconfig-file] (assoc (yaml/parse-string (slurp kubeconfig-file))
+                                          ::kubeconfig-file kubeconfig-file)))))
 
 
 (defn context

--- a/test/kubernetes_api/interceptors/auth/ssl_test.clj
+++ b/test/kubernetes_api/interceptors/auth/ssl_test.clj
@@ -1,0 +1,69 @@
+(ns kubernetes-api.interceptors.auth.ssl-test
+  (:require [clojure.test :refer :all]
+            [kubernetes-api.interceptors.auth.ssl :as ssl])
+  (:import (java.io StringWriter)
+           (java.security KeyPairGenerator Security PrivateKey)
+           (java.util Base64)
+           (org.bouncycastle.asn1.pkcs PrivateKeyInfo)
+           (org.bouncycastle.jce.provider BouncyCastleProvider)
+           (org.bouncycastle.openssl.jcajce JcaPEMWriter)
+           (org.bouncycastle.util.io.pem PemObject PemWriter)))
+
+;; Register BC provider so KeyPairGenerator produces BC-native key types,
+;; which JcaPEMWriter can fully serialize (including EC public key in SEC1).
+(Security/addProvider (BouncyCastleProvider.))
+
+(defn- generate-private-key [algorithm]
+  (let [gen (KeyPairGenerator/getInstance algorithm "BC")]
+    (case algorithm
+      "RSA" (.initialize gen 2048)
+      "EC"  (.initialize gen (java.security.spec.ECGenParameterSpec. "secp256r1")))
+    (-> gen .generateKeyPair .getPrivate)))
+
+(defn- private-key->pkcs8-pem
+  "Serializes to PKCS#8 PEM (BEGIN PRIVATE KEY) by writing the PrivateKeyInfo directly."
+  [^PrivateKey k]
+  (let [pki (PrivateKeyInfo/getInstance (.getEncoded k))
+        sw  (StringWriter.)]
+    (with-open [w (JcaPEMWriter. sw)]
+      (.writeObject w pki))
+    (.toString sw)))
+
+(defn- private-key->pkcs1-pem
+  "Serializes to PKCS#1 PEM using JcaPEMWriter on the raw key (RSA → BEGIN RSA PRIVATE KEY,
+  EC → BEGIN EC PRIVATE KEY)."
+  [^PrivateKey k]
+  (let [sw (StringWriter.)]
+    (with-open [w (JcaPEMWriter. sw)]
+      (.writeObject w k))
+    (.toString sw)))
+
+(defn- pem->base64 [^String pem]
+  (.encodeToString (Base64/getEncoder) (.getBytes pem "UTF-8")))
+
+(deftest base64->private-key-test
+  (testing "PKCS#8 RSA private key (BEGIN PRIVATE KEY)"
+    (let [k   (generate-private-key "RSA")
+          b64 (pem->base64 (private-key->pkcs8-pem k))]
+      (is (instance? PrivateKey (ssl/base64->private-key b64)))
+      (is (= "RSA" (.getAlgorithm ^PrivateKey (ssl/base64->private-key b64))))))
+
+  (testing "PKCS#1 RSA private key (BEGIN RSA PRIVATE KEY)"
+    (let [k   (generate-private-key "RSA")
+          b64 (pem->base64 (private-key->pkcs1-pem k))]
+      (is (instance? PrivateKey (ssl/base64->private-key b64)))
+      (is (= "RSA" (.getAlgorithm ^PrivateKey (ssl/base64->private-key b64))))))
+
+  (testing "PKCS#8 EC private key (BEGIN PRIVATE KEY)"
+    (let [k   (generate-private-key "EC")
+          b64 (pem->base64 (private-key->pkcs8-pem k))
+          pk  (ssl/base64->private-key b64)]
+      (is (instance? PrivateKey pk))
+      (is (contains? #{"EC" "ECDSA"} (.getAlgorithm ^PrivateKey pk)))))
+
+  (testing "PKCS#1 EC private key (BEGIN EC PRIVATE KEY)"
+    (let [k   (generate-private-key "EC")
+          b64 (pem->base64 (private-key->pkcs1-pem k))
+          pk  (ssl/base64->private-key b64)]
+      (is (instance? PrivateKey pk))
+      (is (contains? #{"EC" "ECDSA"} (.getAlgorithm ^PrivateKey pk))))))


### PR DESCRIPTION
**New: kubeconfig loader**
- Adds `kubernetes-api.loader.kubeconfig/context` to load a named context from kubeconfig file(s). Supports explicit paths, the `KUBECONFIG` env var (colon-separated), and the default `~/.kube/config`.


**New: `from-context` in core**
- Adds `kubernetes-api.core/from-context` to construct a client directly from a loaded kubeconfig context.

**Improved SSL support**
- `kubernetes-api.interceptors.auth.ssl` now handles PKCS#1, ECDSA, and other BouncyCastle-supported private key formats in addition to PKCS#8.

**Docs & tests**
- README updated with kubeconfig loader usage examples.
- SSL interceptor tests added.